### PR TITLE
Add `From` conversions for `HeaderValue`(s) to Raw 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,29 +1,29 @@
 [[package]]
 name = "base64"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -33,33 +33,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "http"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyperx"
 version = "0.13.1"
 dependencies = [
- "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -67,13 +67,13 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -83,23 +83,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.43"
+version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,12 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.40"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safemem"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -122,22 +122,22 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicase"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "version_check"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -147,7 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,26 +165,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
-"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
-"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum http 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7fd7d757dfc163d8e00b084f8961a14e15489b494b553bd1738348829a5a26f9"
-"checksum httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b6288d7db100340ca12873fd4d08ad1b8f206a9457798dfb17c018a33fee540"
+"checksum http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "02096a6d2c55e63f7fcb800690e4f889a25f6ec342e3adb4594e293b625215ab"
+"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
-"checksum mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4b082692d3f6cf41b453af73839ce3dfc212c4411cbb2441dff80a716e38bd79"
+"checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0a907b83e7b9e987032439a387e187119cddafc92d5c2aaeb1d92580a793f630"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
-"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
+"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -1067,11 +1067,7 @@ mod tests {
                       "br".parse().unwrap());
 
         let vals = hheads.get_all(http::header::CONTENT_ENCODING);
-        let mut raw = Raw::empty();
-        for v in vals {
-            raw.push(v);
-        }
-        let ce = ContentEncoding::parse_header(&raw).unwrap();
+        let ce = ContentEncoding::parse_header(&vals.into()).unwrap();
         assert_eq!(
             ce,
             ContentEncoding(vec![

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -767,7 +767,8 @@ impl PartialEq<HeaderName> for str {
 #[cfg(test)]
 mod tests {
     use std::fmt;
-    use super::{Headers, Header, Raw, ContentLength, ContentType, Host, SetCookie};
+    use super::{Headers, Header, Raw, ContentLength, ContentType, ContentEncoding,
+                Encoding, Host, SetCookie};
 
     #[cfg(feature = "nightly")]
     use test::Bencher;
@@ -1041,6 +1042,18 @@ mod tests {
         // Test Headers::from(&http::HeaderMap)
         let conv_hyper_headers: Headers = Headers::from(&orig_http_headers);
         assert_eq!(orig_hyper_headers, conv_hyper_headers);
+    }
+
+    #[test]
+    #[cfg(feature = "compat")]
+    fn test_compat_value_parse() {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+        let ce = ContentEncoding::parse_header(&Raw::from(val.as_bytes())).unwrap();
+        assert_eq!(ce, ContentEncoding(vec![Encoding::Chunked, Encoding::Gzip]))
     }
 
     #[cfg(feature = "nightly")]

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -1129,6 +1129,35 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[bench]
+    #[cfg(feature = "compat")]
+    fn bench_compat_value_parse(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            ContentEncoding::parse_header(&val.into()).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    #[cfg(feature = "compat")]
+    fn bench_compat_value_parse_str(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            let val = val.to_str().unwrap();
+            ContentEncoding::parse_header(&val.into()).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
     fn bench_headers_new(b: &mut Bencher) {
         b.iter(|| {
             let mut h = Headers::new();

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -1052,7 +1052,7 @@ mod tests {
         hheads.insert(http::header::CONTENT_ENCODING,
                       "chunked, gzip".parse().unwrap());
         let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
-        let ce = ContentEncoding::parse_header(&Raw::from(val.as_bytes())).unwrap();
+        let ce = ContentEncoding::parse_header(&val.into()).unwrap();
         assert_eq!(ce, ContentEncoding(vec![Encoding::Chunked, Encoding::Gzip]))
     }
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -1130,6 +1130,21 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     #[cfg(feature = "compat")]
+    fn bench_compat_value_parse_extra_str(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            let val = val.to_str().unwrap();
+            ContentEncoding::parse_header(&val.into()).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    #[cfg(feature = "compat")]
     fn bench_compat_value_parse(b: &mut Bencher) {
         use http;
         let mut hheads = http::HeaderMap::new();
@@ -1144,15 +1159,13 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     #[cfg(feature = "compat")]
-    fn bench_compat_value_parse_str(b: &mut Bencher) {
+    fn bench_compat_value_parse_int(b: &mut Bencher) {
         use http;
         let mut hheads = http::HeaderMap::new();
-        hheads.insert(http::header::CONTENT_ENCODING,
-                      "chunked, gzip".parse().unwrap());
+        hheads.insert(http::header::CONTENT_LENGTH, "1024".parse().unwrap());
         b.iter(|| {
-            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
-            let val = val.to_str().unwrap();
-            ContentEncoding::parse_header(&val.into()).unwrap();
+            let val = hheads.get(http::header::CONTENT_LENGTH).unwrap();
+            ContentLength::parse_header(&val.into()).unwrap();
         })
     }
 

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -3,18 +3,13 @@ use std::fmt;
 use bytes::Bytes;
 
 #[cfg(feature = "compat")]
-use http::header::HeaderValue;
+use http::header::{GetAll, HeaderValue};
 
 /// A raw header value.
 #[derive(Clone, Debug)]
 pub struct Raw(Lines);
 
 impl Raw {
-    /// Construct new empty value
-    pub fn empty() -> Raw {
-        Raw(Lines::Empty)
-    }
-
     /// Returns the amount of lines.
     #[inline]
     pub fn len(&self) -> usize {
@@ -204,6 +199,18 @@ impl<'a> From<&'a HeaderValue> for Raw {
     #[inline]
     fn from(val: &'a HeaderValue) -> Raw {
         Raw(Lines::One(val.as_bytes().into()))
+    }
+}
+
+#[cfg(feature = "compat")]
+impl<'a> From<GetAll<'a, HeaderValue>> for Raw
+{
+    fn from(ga: GetAll<'a, HeaderValue>) -> Raw {
+        let mut raw = new();
+        for v in ga {
+            raw.push(v);
+        }
+        raw
     }
 }
 

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -7,6 +7,11 @@ use bytes::Bytes;
 pub struct Raw(Lines);
 
 impl Raw {
+    /// Construct new empty value
+    pub fn empty() -> Raw {
+        Raw(Lines::Empty)
+    }
+
     /// Returns the amount of lines.
     #[inline]
     pub fn len(&self) -> usize {

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::fmt;
 use bytes::Bytes;
 
+#[cfg(feature = "compat")]
+use http::header::HeaderValue;
+
 /// A raw header value.
 #[derive(Clone, Debug)]
 pub struct Raw(Lines);
@@ -193,6 +196,14 @@ impl From<Bytes> for Raw {
     #[inline]
     fn from(val: Bytes) -> Raw {
         Raw(Lines::One(val))
+    }
+}
+
+#[cfg(feature = "compat")]
+impl<'a> From<&'a HeaderValue> for Raw {
+    #[inline]
+    fn from(val: &'a HeaderValue) -> Raw {
+        Raw(Lines::One(val.as_bytes().into()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //! dependencies, for continued use with hyper 0.12 (current master), where
 //! this module was removed in preference to the byte-oriented `http::header`
 //! module.
+//!
+//! See the [*header*](header/index.html) module for more details.
 
 extern crate base64;
 extern crate bytes;


### PR DESCRIPTION
This improves ergonomics, and more importantly, could save the next developer some time grappling with the types and conversions involved.  See the new doctest in src/header/mod.rs for the best summary. 

Conflicting trait (coherence?) rules prevented implementing some generic `From` over `IntoIterator<Item=HeaderValue>` or `Iterator` to `Raw`, so I've implemented the same directly using the concrete `GetAll` struct as returned by `HeaderMap::get_all`.

This likely warrants bumping to 0.14.0.
