### PR TITLE
Parse headers via `RawLike` trait generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,29 +1,29 @@
 [[package]]
 name = "base64"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -33,33 +33,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "http"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyperx"
 version = "0.13.1"
 dependencies = [
- "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -67,13 +67,13 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -83,23 +83,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.43"
+version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "mime"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,12 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.40"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safemem"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -122,22 +122,22 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "unicase"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "version_check"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -147,7 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,26 +165,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
-"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum bytes 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ce55bd354b095246fc34caf4e9e242f5297a7fd938b090cadfea6eee614aa62"
-"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
+"checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
-"checksum http 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7fd7d757dfc163d8e00b084f8961a14e15489b494b553bd1738348829a5a26f9"
-"checksum httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b6288d7db100340ca12873fd4d08ad1b8f206a9457798dfb17c018a33fee540"
+"checksum http 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "02096a6d2c55e63f7fcb800690e4f889a25f6ec342e3adb4594e293b625215ab"
+"checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5adb58558dcd1d786b5f0bd15f3226ee23486e24b7b58304b60f64dc68e62606"
+"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
-"checksum mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4b082692d3f6cf41b453af73839ce3dfc212c4411cbb2441dff80a716e38bd79"
+"checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum mime 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "0a907b83e7b9e987032439a387e187119cddafc92d5c2aaeb1d92580a793f630"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
-"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
+"checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
+"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "d825be0eb33fda1a7e68012d51e9c7f451dc1a69391e7fdc197060bb8c56667b"
-"checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/src/header/common/access_control_allow_credentials.rs
+++ b/src/header/common/access_control_allow_credentials.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::str;
 use unicase;
-use header::{Header, Raw};
+use header::{Header, RawLike};
 
 /// `Access-Control-Allow-Credentials` header, part of
 /// [CORS](http://www.w3.org/TR/cors/#access-control-allow-headers-response-header)
@@ -48,7 +48,9 @@ impl Header for AccessControlAllowCredentials {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<AccessControlAllowCredentials> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<AccessControlAllowCredentials>
+    where T: RawLike<'a>
+    {
         if let Some(line) = raw.one() {
             let text = unsafe {
                 // safe because:

--- a/src/header/common/access_control_allow_origin.rs
+++ b/src/header/common/access_control_allow_origin.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::str;
 
-use header::{Header, Raw};
+use header::{Header, RawLike};
 
 /// The `Access-Control-Allow-Origin` response header,
 /// part of [CORS](http://www.w3.org/TR/cors/#access-control-allow-origin-response-header)
@@ -61,7 +61,9 @@ impl Header for AccessControlAllowOrigin {
         "Access-Control-Allow-Origin"
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<AccessControlAllowOrigin> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<AccessControlAllowOrigin>
+    where T: RawLike<'a>
+    {
         if let Some(line) = raw.one() {
             Ok(match line {
                 b"*" => AccessControlAllowOrigin::Any,

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -230,7 +230,7 @@ impl FromStr for Bearer {
 #[cfg(test)]
 mod tests {
     use super::{Authorization, Basic, Bearer};
-    use super::super::super::{Headers, Header};
+    use super::super::super::{Headers, Header, Raw};
 
     #[test]
     fn test_raw_auth() {
@@ -241,7 +241,8 @@ mod tests {
 
     #[test]
     fn test_raw_auth_parse() {
-        let header: Authorization<String> = Header::parse_header(&b"foo bar baz".as_ref().into()).unwrap();
+        let r: Raw = b"foo bar baz".as_ref().into();
+        let header: Authorization<String> = Header::parse_header(&r).unwrap();
         assert_eq!(header.0, "foo bar baz");
     }
 
@@ -264,16 +265,16 @@ mod tests {
 
     #[test]
     fn test_basic_auth_parse() {
-        let auth: Authorization<Basic> = Header::parse_header(
-            &b"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".as_ref().into()).unwrap();
+        let r: Raw = b"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".as_ref().into();
+        let auth: Authorization<Basic> = Header::parse_header(&r).unwrap();
         assert_eq!(auth.0.username, "Aladdin");
         assert_eq!(auth.0.password, Some("open sesame".to_owned()));
     }
 
     #[test]
     fn test_basic_auth_parse_no_password() {
-        let auth: Authorization<Basic> = Header::parse_header(
-            &b"Basic QWxhZGRpbjo=".as_ref().into()).unwrap();
+        let r: Raw = b"Basic QWxhZGRpbjo=".as_ref().into();
+        let auth: Authorization<Basic> = Header::parse_header(&r).unwrap();
         assert_eq!(auth.0.username, "Aladdin");
         assert_eq!(auth.0.password, Some("".to_owned()));
     }
@@ -290,8 +291,8 @@ mod tests {
 
     #[test]
     fn test_bearer_auth_parse() {
-        let auth: Authorization<Bearer> = Header::parse_header(
-            &b"Bearer fpKL54jvWmEGVoRdCNjG".as_ref().into()).unwrap();
+        let r: Raw = b"Bearer fpKL54jvWmEGVoRdCNjG".as_ref().into();
+        let auth: Authorization<Bearer> = Header::parse_header(&r).unwrap();
         assert_eq!(auth.0.token, "fpKL54jvWmEGVoRdCNjG");
     }
 }

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 use std::str::{FromStr, from_utf8};
 use std::ops::{Deref, DerefMut};
 use base64::{encode, decode};
-use header::{Header, Raw};
+use header::{Header, RawLike};
 
 /// `Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.2)
 ///
@@ -80,7 +80,9 @@ impl<S: Scheme + Any> Header for Authorization<S> where <S as FromStr>::Err: 'st
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Authorization<S>> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Authorization<S>>
+    where T: RawLike<'a>
+    {
         if let Some(line) = raw.one() {
             let header = try!(from_utf8(line));
             if let Some(scheme) = <S as Scheme>::scheme() {

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 
 /// `Cache-Control` header, defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.2)
@@ -59,7 +59,9 @@ impl Header for CacheControl {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<CacheControl> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<CacheControl>
+    where T: RawLike<'a>
+    {
         let directives = try!(from_comma_delimited(raw));
         if !directives.is_empty() {
             Ok(CacheControl(directives))

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -174,32 +174,36 @@ impl FromStr for CacheDirective {
 
 #[cfg(test)]
 mod tests {
-    use header::Header;
+    use header::{Header, Raw};
     use super::*;
 
     #[test]
     fn test_parse_multiple_headers() {
-        let cache = Header::parse_header(&vec![b"no-cache".to_vec(), b"private".to_vec()].into());
+        let r: Raw = vec![b"no-cache".to_vec(), b"private".to_vec()].into();
+        let cache = Header::parse_header(&r);
         assert_eq!(cache.ok(), Some(CacheControl(vec![CacheDirective::NoCache,
                                                  CacheDirective::Private])))
     }
 
     #[test]
     fn test_parse_argument() {
-        let cache = Header::parse_header(&vec![b"max-age=100, private".to_vec()].into());
+        let r: Raw = vec![b"max-age=100, private".to_vec()].into();
+        let cache = Header::parse_header(&r);
         assert_eq!(cache.ok(), Some(CacheControl(vec![CacheDirective::MaxAge(100),
                                                  CacheDirective::Private])))
     }
 
     #[test]
     fn test_parse_quote_form() {
-        let cache = Header::parse_header(&vec![b"max-age=\"200\"".to_vec()].into());
+        let r: Raw = vec![b"max-age=\"200\"".to_vec()].into();
+        let cache = Header::parse_header(&r);
         assert_eq!(cache.ok(), Some(CacheControl(vec![CacheDirective::MaxAge(200)])))
     }
 
     #[test]
     fn test_parse_extension() {
-        let cache = Header::parse_header(&vec![b"foo, bar=baz".to_vec()].into());
+        let r: Raw = vec![b"foo, bar=baz".to_vec()].into();
+        let cache = Header::parse_header(&r);
         assert_eq!(cache.ok(), Some(CacheControl(vec![
             CacheDirective::Extension("foo".to_owned(), None),
             CacheDirective::Extension("bar".to_owned(), Some("baz".to_owned()))])))
@@ -207,7 +211,8 @@ mod tests {
 
     #[test]
     fn test_parse_bad_syntax() {
-        let cache: ::Result<CacheControl> = Header::parse_header(&vec![b"foo=".to_vec()].into());
+        let r: Raw = vec![b"foo=".to_vec()].into();
+        let cache: ::Result<CacheControl> = Header::parse_header(&r);
         assert_eq!(cache.ok(), None)
     }
 }

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -126,11 +126,11 @@ bench_header!(header, Connection, { vec![b"authorization".to_vec()] });
 #[cfg(test)]
 mod tests {
     use super::{Connection,ConnectionHeader};
-    use header::Header;
+    use header::{Header, Raw};
     use unicase::Ascii;
 
     fn parse_option(header: Vec<u8>) -> Connection {
-        let val = header.into();
+        let val: Raw = header.into();
         let connection: Connection = Header::parse_header(&val).unwrap();
         connection
     }

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -198,14 +198,15 @@ impl fmt::Display for ContentDisposition {
 #[cfg(test)]
 mod tests {
     use super::{ContentDisposition,DispositionType,DispositionParam};
-    use ::header::Header;
+    use ::header::{Header, Raw};
     use ::header::shared::Charset;
 
     #[test]
     fn test_parse_header() {
-        assert!(ContentDisposition::parse_header(&"".into()).is_err());
+        let a: Raw = "".into();
+        assert!(ContentDisposition::parse_header(&a).is_err());
 
-        let a = "form-data; dummy=3; name=upload;\r\n filename=\"sample.png\"".into();
+        let a: Raw = "form-data; dummy=3; name=upload;\r\n filename=\"sample.png\"".into();
         let a: ContentDisposition = ContentDisposition::parse_header(&a).unwrap();
         let b = ContentDisposition {
             disposition: DispositionType::Ext("form-data".to_owned()),
@@ -219,7 +220,7 @@ mod tests {
         };
         assert_eq!(a, b);
 
-        let a = "attachment; filename=\"image.jpg\"".into();
+        let a: Raw = "attachment; filename=\"image.jpg\"".into();
         let a: ContentDisposition = ContentDisposition::parse_header(&a).unwrap();
         let b = ContentDisposition {
             disposition: DispositionType::Attachment,
@@ -231,7 +232,7 @@ mod tests {
         };
         assert_eq!(a, b);
 
-        let a = "attachment; filename*=UTF-8''%c2%a3%20and%20%e2%82%ac%20rates".into();
+        let a: Raw = "attachment; filename*=UTF-8''%c2%a3%20and%20%e2%82%ac%20rates".into();
         let a: ContentDisposition = ContentDisposition::parse_header(&a).unwrap();
         let b = ContentDisposition {
             disposition: DispositionType::Attachment,
@@ -248,17 +249,17 @@ mod tests {
     #[test]
     fn test_display() {
         let as_string = "attachment; filename*=UTF-8'en'%C2%A3%20and%20%E2%82%AC%20rates";
-        let a = as_string.into();
+        let a: Raw = as_string.into();
         let a: ContentDisposition = ContentDisposition::parse_header(&a).unwrap();
         let display_rendered = format!("{}",a);
         assert_eq!(as_string, display_rendered);
 
-        let a = "attachment; filename*=UTF-8''black%20and%20white.csv".into();
+        let a: Raw = "attachment; filename*=UTF-8''black%20and%20white.csv".into();
         let a: ContentDisposition = ContentDisposition::parse_header(&a).unwrap();
         let display_rendered = format!("{}",a);
         assert_eq!("attachment; filename=\"black and white.csv\"".to_owned(), display_rendered);
 
-        let a = "attachment; filename=colourful.csv".into();
+        let a: Raw = "attachment; filename=colourful.csv".into();
         let a: ContentDisposition = ContentDisposition::parse_header(&a).unwrap();
         let display_rendered = format!("{}",a);
         assert_eq!("attachment; filename=\"colourful.csv\"".to_owned(), display_rendered);

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -10,7 +10,7 @@ use language_tags::LanguageTag;
 use std::fmt;
 use unicase;
 
-use header::{Header, Raw, parsing};
+use header::{Header, RawLike, parsing};
 use header::parsing::{parse_extended_value, http_percent_encode};
 use header::shared::Charset;
 
@@ -95,7 +95,9 @@ impl Header for ContentDisposition {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<ContentDisposition> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<ContentDisposition>
+    where T: RawLike<'a>
+    {
         parsing::from_one_raw_str(raw).and_then(|s: String| {
             let mut sections = s.split(';');
             let disposition = match sections.next() {

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use header::{Header, Raw, parsing};
+use header::{Header, RawLike, parsing};
 
 /// `Content-Length` header, defined in
 /// [RFC7230](http://tools.ietf.org/html/rfc7230#section-3.3.2)
@@ -49,7 +49,9 @@ impl Header for ContentLength {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<ContentLength> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<ContentLength>
+    where T: RawLike<'a>
+    {
         // If multiple Content-Length headers were sent, everything can still
         // be alright if they all contain the same value, and all parse
         // correctly. If not, then it's an error.

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -93,8 +93,8 @@ __hyper__tm!(ContentLength, tests {
     // Can't use the test_header macro because "5, 5" gets cleaned to "5".
     #[test]
     fn test_duplicates() {
-        let parsed = HeaderField::parse_header(&vec![b"5".to_vec(),
-                                                 b"5".to_vec()].into()).unwrap();
+        let r: Raw = vec![b"5".to_vec(), b"5".to_vec()].into();
+        let parsed = HeaderField::parse_header(&r).unwrap();
         assert_eq!(parsed, HeaderField(5));
         assert_eq!(format!("{}", parsed), "5");
     }

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::str::from_utf8;
 
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use header::internals::VecMap;
 
 /// `Cookie` header, defined in [RFC6265](http://tools.ietf.org/html/rfc6265#section-5.4)
@@ -116,7 +116,9 @@ impl Header for Cookie {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Cookie> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Cookie>
+    where T: RawLike<'a>
+    {
         let mut vec_map = VecMap::with_capacity(raw.len());
         for cookies_raw in raw.iter() {
             let cookies_str = try!(from_utf8(&cookies_raw[..]));

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -193,7 +193,7 @@ impl<'a> Iterator for CookieIter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use header::Header;
+    use header::{Header, Raw};
     use super::Cookie;
 
     #[test]
@@ -243,47 +243,47 @@ mod tests {
     #[test]
     fn test_parse() {
         let mut cookie = Cookie::new();
-
-        let parsed = Cookie::parse_header(&b"foo=bar".to_vec().into()).unwrap();
+        let r: Raw = b"foo=bar".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         cookie.append("foo", "bar");
         assert_eq!(cookie, parsed);
 
-        let parsed = Cookie::parse_header(&b"foo=bar;".to_vec().into()).unwrap();
+        let parsed = Cookie::parse_header(&r).unwrap();
         assert_eq!(cookie, parsed);
 
-        let parsed = Cookie::parse_header(&b"foo=bar; baz=quux".to_vec().into()).unwrap();
+        let r: Raw = b"foo=bar; baz=quux".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         cookie.append("baz", "quux");
         assert_eq!(cookie, parsed);
 
-        let parsed = Cookie::parse_header(&b"foo=bar;; baz=quux".to_vec().into()).unwrap();
+        let r: Raw = b"foo=bar;; baz=quux".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         assert_eq!(cookie, parsed);
 
-        let parsed = Cookie::parse_header(&b"foo=bar; invalid ; bad; ;; baz=quux".to_vec().into())
-            .unwrap();
+        let r: Raw = b"foo=bar; invalid ; bad; ;; baz=quux".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         assert_eq!(cookie, parsed);
 
-        let parsed = Cookie::parse_header(&b" foo  =    bar;baz= quux  ".to_vec().into()).unwrap();
+        let r: Raw = b" foo  =    bar;baz= quux  ".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         assert_eq!(cookie, parsed);
 
-        let parsed =
-            Cookie::parse_header(&vec![b"foo  =    bar".to_vec(), b"baz= quux  ".to_vec()].into())
-                .unwrap();
+        let r: Raw = vec![b"foo  =    bar".to_vec(), b"baz= quux  ".to_vec()].into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         assert_eq!(cookie, parsed);
-
-        let parsed = Cookie::parse_header(&b"foo=bar; baz=quux ; empty=".to_vec().into()).unwrap();
+        let r: Raw = b"foo=bar; baz=quux ; empty=".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         cookie.append("empty", "");
         assert_eq!(cookie, parsed);
 
-
         let mut cookie = Cookie::new();
-
-        let parsed = Cookie::parse_header(&b"middle=equals=in=the=middle".to_vec().into()).unwrap();
+        let r: Raw = b"middle=equals=in=the=middle".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         cookie.append("middle", "equals=in=the=middle");
         assert_eq!(cookie, parsed);
 
-        let parsed =
-            Cookie::parse_header(&b"middle=equals=in=the=middle; double==2".to_vec().into())
-                .unwrap();
+        let r: Raw = b"middle=equals=in=the=middle; double==2".to_vec().into();
+        let parsed = Cookie::parse_header(&r).unwrap();
         cookie.append("double", "=2");
         assert_eq!(cookie, parsed);
     }

--- a/src/header/common/expect.rs
+++ b/src/header/common/expect.rs
@@ -3,7 +3,7 @@ use std::str;
 
 use unicase;
 
-use header::{Header, Raw};
+use header::{Header, RawLike};
 
 /// The `Expect` header.
 ///
@@ -32,7 +32,9 @@ impl Header for Expect {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Expect> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Expect>
+    where T: RawLike<'a>
+    {
         if let Some(line) = raw.one() {
             let text = unsafe {
                 // safe because:

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
 
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use header::parsing::from_one_raw_str;
 
 /// The `Host` header.
@@ -64,8 +64,10 @@ impl Header for Host {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Host> {
-       from_one_raw_str(raw)
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Host>
+    where T: RawLike<'a>
+    {
+        from_one_raw_str(raw)
     }
 
     fn fmt_header(&self, f: &mut ::header::Formatter) -> fmt::Result {

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -107,25 +107,29 @@ impl FromStr for Host {
 #[cfg(test)]
 mod tests {
     use super::Host;
-    use header::Header;
+    use header::{Header, Raw};
 
 
     #[test]
     fn test_host() {
-        let host = Header::parse_header(&vec![b"foo.com".to_vec()].into());
+        let r: Raw = vec![b"foo.com".to_vec()].into();
+        let host = Header::parse_header(&r);
         assert_eq!(host.ok(), Some(Host::new("foo.com", None)));
 
-
-        let host = Header::parse_header(&vec![b"foo.com:8080".to_vec()].into());
+        let r: Raw = vec![b"foo.com:8080".to_vec()].into();
+        let host = Header::parse_header(&r);
         assert_eq!(host.ok(), Some(Host::new("foo.com", Some(8080))));
 
-        let host = Header::parse_header(&vec![b"foo.com".to_vec()].into());
+        let r: Raw = vec![b"foo.com".to_vec()].into();
+        let host = Header::parse_header(&r);
         assert_eq!(host.ok(), Some(Host::new("foo.com", None)));
 
-        let host = Header::parse_header(&vec![b"[::1]:8080".to_vec()].into());
+        let r: Raw = vec![b"[::1]:8080".to_vec()].into();
+        let host = Header::parse_header(&r);
         assert_eq!(host.ok(), Some(Host::new("[::1]", Some(8080))));
 
-        let host = Header::parse_header(&vec![b"[::1]".to_vec()].into());
+        let r: Raw = vec![b"[::1]".to_vec()].into();
+        let host = Header::parse_header(&r);
         assert_eq!(host.ok(), Some(Host::new("[::1]", None)));
     }
 }

--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -64,17 +64,19 @@ header! {
 #[cfg(test)]
 mod tests {
     use super::IfNoneMatch;
-    use header::Header;
+    use header::{Header, Raw};
     use header::EntityTag;
 
     #[test]
     fn test_if_none_match() {
         let mut if_none_match: ::Result<IfNoneMatch>;
 
-        if_none_match = Header::parse_header(&b"*".as_ref().into());
+        let r: Raw = b"*".as_ref().into();
+        if_none_match = Header::parse_header(&r);
         assert_eq!(if_none_match.ok(), Some(IfNoneMatch::Any));
 
-        if_none_match = Header::parse_header(&b"\"foobar\", W/\"weak-etag\"".as_ref().into());
+        let r: Raw = b"\"foobar\", W/\"weak-etag\"".as_ref().into();
+        if_none_match = Header::parse_header(&r);
         let mut entities: Vec<EntityTag> = Vec::new();
         let foobar_etag = EntityTag::new(false, "foobar".to_owned());
         let weak_etag = EntityTag::new(true, "weak-etag".to_owned());

--- a/src/header/common/if_range.rs
+++ b/src/header/common/if_range.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Display};
-use header::{self, Header, Raw, EntityTag, HttpDate};
+use header::{self, Header, RawLike, EntityTag, HttpDate};
 
 /// `If-Range` header, defined in [RFC7233](http://tools.ietf.org/html/rfc7233#section-3.2)
 ///
@@ -57,7 +57,9 @@ impl Header for IfRange {
         static NAME: &'static str = "If-Range";
         NAME
     }
-    fn parse_header(raw: &Raw) -> ::Result<IfRange> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<IfRange>
+    where T: RawLike<'a>
+    {
         let etag: ::Result<EntityTag> = header::parsing::from_one_raw_str(raw);
         if let Ok(etag) = etag {
             return Ok(IfRange::EntityTag(etag));

--- a/src/header/common/last_event_id.rs
+++ b/src/header/common/last_event_id.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Display};
-use header::{self, Header, Raw};
+use header::{self, Header, RawLike};
 
 /// `Last-Event-ID` header, defined in
 /// [RFC3864](https://html.spec.whatwg.org/multipage/references.html#refsRFC3864)
@@ -32,7 +32,9 @@ impl Header for LastEventId {
     }
 
     #[inline]
-    fn parse_header(raw: &Raw) -> ::Result<Self> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Self>
+    where T: RawLike<'a>
+    {
         match raw.one() {
             Some(line) if line.is_empty() => Ok(LastEventId("".to_owned())),
             Some(line) => header::parsing::from_raw_str(line).map(LastEventId),

--- a/src/header/common/link.rs
+++ b/src/header/common/link.rs
@@ -899,7 +899,7 @@ mod tests {
     use super::{Link, LinkValue, MediaDesc, RelationType, SplitAsciiUnquoted};
     use super::{fmt_delimited, verify_and_trim};
 
-    use header::Header;
+    use header::{Header, Raw};
 
     use mime;
 
@@ -915,7 +915,8 @@ mod tests {
 
         let expected_link = Link::new(vec![link_value]);
 
-        let link = Header::parse_header(&vec![link_header.to_vec()].into());
+        let r: Raw = vec![link_header.to_vec()].into();
+        let link = Header::parse_header(&r);
         assert_eq!(link.ok(), Some(expected_link));
     }
 
@@ -936,7 +937,8 @@ mod tests {
 
         let expected_link = Link::new(vec![first_link, second_link]);
 
-        let link = Header::parse_header(&vec![link_header.to_vec()].into());
+        let r: Raw = vec![link_header.to_vec()].into();
+        let link = Header::parse_header(&r);
         assert_eq!(link.ok(), Some(expected_link));
     }
 
@@ -960,7 +962,8 @@ mod tests {
 
         let expected_link = Link::new(vec![link_value]);
 
-        let link = Header::parse_header(&vec![link_header.to_vec()].into());
+        let r: Raw = vec![link_header.to_vec()].into();
+        let link = Header::parse_header(&r);
         assert_eq!(link.ok(), Some(expected_link));
     }
 
@@ -995,31 +998,32 @@ mod tests {
         let link_a  = b"http://example.com/TheBook/chapter2; \
             rel=\"previous\"; rev=next; title=\"previous chapter\"";
 
-        let mut err: Result<Link, _> = Header::parse_header(&vec![link_a.to_vec()].into());
+        let r: Raw = vec![link_a.to_vec()].into();
+        let mut err: Result<Link, _> = Header::parse_header(&r);
         assert_eq!(err.is_err(), true);
 
         let link_b = b"<http://example.com/TheBook/chapter2>; \
             =\"previous\"; rev=next; title=\"previous chapter\"";
-
-        err = Header::parse_header(&vec![link_b.to_vec()].into());
+        let r: Raw = vec![link_b.to_vec()].into();
+        err = Header::parse_header(&r);
         assert_eq!(err.is_err(), true);
 
         let link_c = b"<http://example.com/TheBook/chapter2>; \
             rel=; rev=next; title=\"previous chapter\"";
-
-        err = Header::parse_header(&vec![link_c.to_vec()].into());
+        let r: Raw = vec![link_c.to_vec()].into();
+        err = Header::parse_header(&r);
         assert_eq!(err.is_err(), true);
 
         let link_d = b"<http://example.com/TheBook/chapter2>; \
             rel=\"previous\"; rev=next; title=";
-
-        err = Header::parse_header(&vec![link_d.to_vec()].into());
+        let r: Raw = vec![link_d.to_vec()].into();
+        err = Header::parse_header(&r);
         assert_eq!(err.is_err(), true);
 
         let link_e = b"<http://example.com/TheBook/chapter2>; \
             rel=\"previous\"; rev=next; attr=unknown";
-
-        err = Header::parse_header(&vec![link_e.to_vec()].into());
+        let r: Raw = vec![link_e.to_vec()].into();
+        err = Header::parse_header(&r);
         assert_eq!(err.is_err(), true);
      }
 

--- a/src/header/common/link.rs
+++ b/src/header/common/link.rs
@@ -8,7 +8,7 @@ use mime::Mime;
 use language_tags::LanguageTag;
 
 use header::parsing;
-use header::{Header, Raw};
+use header::{Header, RawLike};
 
 /// The `Link` header, defined in
 /// [RFC5988](http://tools.ietf.org/html/rfc5988#section-5)
@@ -391,7 +391,9 @@ impl Header for Link {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Link> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Link>
+    where T: RawLike<'a>
+    {
         // If more that one `Link` headers are present in a request's
         // headers they are combined in a single `Link` header containing
         // all the `link-value`s present in each of those `Link` headers.

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -75,11 +75,11 @@ macro_rules! bench_header(
             use test::Bencher;
             use super::*;
 
-            use header::{Header};
+            use header::{Header, Raw};
 
             #[bench]
             fn bench_parse(b: &mut Bencher) {
-                let val = $value.into();
+                let val: Raw = $value.into();
                 b.iter(|| {
                     let _: $ty = Header::parse_header(&val).unwrap();
                 });
@@ -87,7 +87,7 @@ macro_rules! bench_header(
 
             #[bench]
             fn bench_format(b: &mut Bencher) {
-                let raw = $value.into();
+                let raw: Raw = $value.into();
                 let val: $ty = Header::parse_header(&raw).unwrap();
                 b.iter(|| {
                     format!("{}", val);

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -147,7 +147,7 @@ macro_rules! test_header {
             use std::ascii::AsciiExt;
             let raw = $raw;
             let a: Vec<Vec<u8>> = raw.iter().map(|x| x.to_vec()).collect();
-            let a = a.into();
+            let a: Raw = a.into();
             let value = HeaderField::parse_header(&a);
             let result = format!("{}", value.unwrap());
             let expected = String::from_utf8(raw[0].to_vec()).unwrap();
@@ -167,8 +167,9 @@ macro_rules! test_header {
     ($id:ident, $raw:expr, $typed:expr) => {
         #[test]
         fn $id() {
+
             let a: Vec<Vec<u8>> = $raw.iter().map(|x| x.to_vec()).collect();
-            let a = a.into();
+            let a: Raw = a.into();
             let val = HeaderField::parse_header(&a);
             let typed: Option<HeaderField> = $typed;
             // Test parsing

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -208,7 +208,9 @@ macro_rules! header {
                 NAME
             }
             #[inline]
-            fn parse_header(raw: &$crate::header::Raw) -> $crate::Result<Self> {
+            fn parse_header<'a, T>(raw: &'a T) -> $crate::Result<Self>
+            where T: $crate::header::RawLike<'a>
+            {
                 $crate::header::parsing::from_comma_delimited(raw).map($id)
             }
             #[inline]
@@ -236,7 +238,9 @@ macro_rules! header {
                 NAME
             }
             #[inline]
-            fn parse_header(raw: &$crate::header::Raw) -> $crate::Result<Self> {
+            fn parse_header<'a, T>(raw: &'a T) -> $crate::Result<Self>
+            where T: $crate::header::RawLike<'a>
+            {
                 $crate::header::parsing::from_comma_delimited(raw).map($id)
             }
             #[inline]
@@ -264,7 +268,9 @@ macro_rules! header {
                 NAME
             }
             #[inline]
-            fn parse_header(raw: &$crate::header::Raw) -> $crate::Result<Self> {
+            fn parse_header<'a, T>(raw: &'a T) -> $crate::Result<Self>
+            where T: $crate::header::RawLike<'a>
+            {
                 $crate::header::parsing::from_one_raw_str(raw).map($id)
             }
             #[inline]
@@ -292,7 +298,9 @@ macro_rules! header {
                 NAME
             }
             #[inline]
-            fn parse_header(raw: &$crate::header::Raw) -> $crate::Result<Self> {
+            fn parse_header<'a, T>(raw: &'a T) -> $crate::Result<Self>
+            where T: $crate::header::RawLike<'a>
+            {
                 $crate::header::parsing::from_one_raw_str(raw).map($id)
             }
             #[inline]
@@ -332,8 +340,10 @@ macro_rules! header {
                 NAME
             }
             #[inline]
-            fn parse_header(raw: &$crate::header::Raw) -> $crate::Result<Self> {
-                $crate::header::parsing::from_one_raw_str::<<$value as ::std::borrow::ToOwned>::Owned>(raw).map($id::new)
+            fn parse_header<'a, T>(raw: &'a T) -> $crate::Result<Self>
+            where T: $crate::header::RawLike<'a>
+            {
+                $crate::header::parsing::from_one_raw_str::<_, <$value as ::std::borrow::ToOwned>::Owned>(raw).map($id::new)
             }
             #[inline]
             fn fmt_header(&self, f: &mut $crate::header::Formatter) -> ::std::fmt::Result {
@@ -364,10 +374,12 @@ macro_rules! header {
                 NAME
             }
             #[inline]
-            fn parse_header(raw: &$crate::header::Raw) -> $crate::Result<Self> {
+            fn parse_header<'a, T>(raw: &'a T) -> $crate::Result<Self>
+            where T: $crate::header::RawLike<'a>
+            {
                 // FIXME: Return None if no item is in $id::Only
-                if raw.len() == 1 {
-                    if &raw[0] == b"*" {
+                if let Some(l) = raw.one() {
+                    if l == b"*" {
                         return Ok($id::Any)
                     }
                 }

--- a/src/header/common/origin.rs
+++ b/src/header/common/origin.rs
@@ -1,4 +1,4 @@
-use header::{Header, Raw, Host};
+use header::{Header, RawLike, Host};
 use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
@@ -104,7 +104,9 @@ impl Header for Origin {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Origin> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Origin>
+    where T: RawLike<'a>
+    {
         from_one_raw_str(raw)
     }
 

--- a/src/header/common/origin.rs
+++ b/src/header/common/origin.rs
@@ -156,7 +156,7 @@ impl fmt::Display for Origin {
 #[cfg(test)]
 mod tests {
     use super::Origin;
-    use header::Header;
+    use header::{Header, Raw};
     use std::borrow::Cow;
 
     macro_rules! assert_borrowed{
@@ -170,11 +170,13 @@ mod tests {
 
     #[test]
     fn test_origin() {
-        let origin : Origin = Header::parse_header(&vec![b"http://foo.com".to_vec()].into()).unwrap();
+        let r: Raw = vec![b"http://foo.com".to_vec()].into();
+        let origin : Origin = Header::parse_header(&r).unwrap();
         assert_eq!(&origin, &Origin::new("http", "foo.com", None));
         assert_borrowed!(origin.scheme().unwrap().into());
 
-        let origin : Origin = Header::parse_header(&vec![b"https://foo.com:443".to_vec()].into()).unwrap();
+        let r: Raw = vec![b"https://foo.com:443".to_vec()].into();
+        let origin : Origin = Header::parse_header(&r).unwrap();
         assert_eq!(&origin, &Origin::new("https", "foo.com", Some(443)));
         assert_borrowed!(origin.scheme().unwrap().into());
     }

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -76,12 +76,19 @@ impl fmt::Display for Pragma {
 
 #[test]
 fn test_parse_header() {
-    let a: Pragma = Header::parse_header(&"no-cache".into()).unwrap();
+    use header::{Header, Raw};
+
+    let r: Raw = "no-cache".into();
+    let a: Pragma = Header::parse_header(&r).unwrap();
     let b = Pragma::NoCache;
     assert_eq!(a, b);
-    let c: Pragma = Header::parse_header(&"FoObar".into()).unwrap();
+
+    let r: Raw = "FoObar".into();
+    let c: Pragma = Header::parse_header(&r).unwrap();
     let d = Pragma::Ext("FoObar".to_owned());
     assert_eq!(c, d);
-    let e: ::Result<Pragma> = Header::parse_header(&"".into());
+
+    let r: Raw = "".into();
+    let e: ::Result<Pragma> = Header::parse_header(&r);
     assert_eq!(e.ok(), None);
 }

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -2,7 +2,7 @@ use std::fmt;
 #[allow(unused, deprecated)]
 use std::ascii::AsciiExt;
 
-use header::{Header, Raw, parsing};
+use header::{Header, RawLike, parsing};
 
 /// The `Pragma` header defined by HTTP/1.0.
 ///
@@ -48,7 +48,9 @@ impl Header for Pragma {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Pragma> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Pragma>
+    where T: RawLike<'a>
+    {
         parsing::from_one_raw_str(raw).and_then(|s: String| {
             let slice = &s.to_ascii_lowercase()[..];
             match slice {

--- a/src/header/common/prefer.rs
+++ b/src/header/common/prefer.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 
 /// `Prefer` header, defined in [RFC7240](http://tools.ietf.org/html/rfc7240)
@@ -59,7 +59,9 @@ impl Header for Prefer {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Prefer> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Prefer>
+    where T: RawLike<'a>
+    {
         let preferences = try!(from_comma_delimited(raw));
         if !preferences.is_empty() {
             Ok(Prefer(preferences))

--- a/src/header/common/prefer.rs
+++ b/src/header/common/prefer.rs
@@ -165,19 +165,21 @@ impl FromStr for Preference {
 
 #[cfg(test)]
 mod tests {
-    use header::Header;
+    use header::{Header, Raw};
     use super::*;
 
     #[test]
     fn test_parse_multiple_headers() {
-        let prefer = Header::parse_header(&"respond-async, return=representation".into());
+        let r: Raw = "respond-async, return=representation".into();
+        let prefer = Header::parse_header(&r);
         assert_eq!(prefer.ok(), Some(Prefer(vec![Preference::RespondAsync,
                                            Preference::ReturnRepresentation])))
     }
 
     #[test]
     fn test_parse_argument() {
-        let prefer = Header::parse_header(&"wait=100, handling=lenient, respond-async".into());
+        let r: Raw = "wait=100, handling=lenient, respond-async".into();
+        let prefer = Header::parse_header(&r);
         assert_eq!(prefer.ok(), Some(Prefer(vec![Preference::Wait(100),
                                            Preference::HandlingLenient,
                                            Preference::RespondAsync])))
@@ -185,14 +187,17 @@ mod tests {
 
     #[test]
     fn test_parse_quote_form() {
-        let prefer = Header::parse_header(&"wait=\"200\", handling=\"strict\"".into());
+        let r: Raw = "wait=\"200\", handling=\"strict\"".into();
+        let prefer = Header::parse_header(&r);
         assert_eq!(prefer.ok(), Some(Prefer(vec![Preference::Wait(200),
                                            Preference::HandlingStrict])))
     }
 
     #[test]
     fn test_parse_extension() {
-        let prefer = Header::parse_header(&"foo, bar=baz, baz; foo; bar=baz, bux=\"\"; foo=\"\", buz=\"some parameter\"".into());
+        let r: Raw = "foo, bar=baz, baz; foo; bar=baz, bux=\"\"; \
+                      foo=\"\", buz=\"some parameter\"".into();
+        let prefer = Header::parse_header(&r);
         assert_eq!(prefer.ok(), Some(Prefer(vec![
             Preference::Extension("foo".to_owned(), "".to_owned(), vec![]),
             Preference::Extension("bar".to_owned(), "baz".to_owned(), vec![]),
@@ -203,7 +208,8 @@ mod tests {
 
     #[test]
     fn test_fail_with_args() {
-        let prefer: ::Result<Prefer> = Header::parse_header(&"respond-async; foo=bar".into());
+        let r: Raw = "respond-async; foo=bar".into();
+        let prefer: ::Result<Prefer> = Header::parse_header(&r);
         assert_eq!(prefer.ok(), None);
     }
 }

--- a/src/header/common/preference_applied.rs
+++ b/src/header/common/preference_applied.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use header::{Header, Raw, Preference};
+use header::{Header, RawLike, Preference};
 use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 
 /// `Preference-Applied` header, defined in [RFC7240](http://tools.ietf.org/html/rfc7240)
@@ -58,7 +58,9 @@ impl Header for PreferenceApplied {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<PreferenceApplied> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<PreferenceApplied>
+    where T: RawLike<'a>
+    {
         let preferences = try!(from_comma_delimited(raw));
         if !preferences.is_empty() {
             Ok(PreferenceApplied(preferences))

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -122,7 +122,7 @@ impl<S: Scheme> fmt::Display for ProxyAuthorization<S> {
 #[cfg(test)]
 mod tests {
     use super::ProxyAuthorization;
-    use super::super::super::{Headers, Header, Basic, Bearer};
+    use super::super::super::{Headers, Header, Raw, Basic, Bearer};
 
     #[test]
     fn test_raw_auth() {
@@ -133,7 +133,8 @@ mod tests {
 
     #[test]
     fn test_raw_auth_parse() {
-        let header: ProxyAuthorization<String> = Header::parse_header(&b"foo bar baz".as_ref().into()).unwrap();
+        let r: Raw = b"foo bar baz".as_ref().into();
+        let header: ProxyAuthorization<String> = Header::parse_header(&r).unwrap();
         assert_eq!(header.0, "foo bar baz");
     }
 
@@ -156,16 +157,16 @@ mod tests {
 
     #[test]
     fn test_basic_auth_parse() {
-        let auth: ProxyAuthorization<Basic> = Header::parse_header(
-            &b"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".as_ref().into()).unwrap();
+        let r: Raw = b"Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==".as_ref().into();
+        let auth: ProxyAuthorization<Basic> = Header::parse_header(&r).unwrap();
         assert_eq!(auth.0.username, "Aladdin");
         assert_eq!(auth.0.password, Some("open sesame".to_owned()));
     }
 
     #[test]
     fn test_basic_auth_parse_no_password() {
-        let auth: ProxyAuthorization<Basic> = Header::parse_header(
-            &b"Basic QWxhZGRpbjo=".as_ref().into()).unwrap();
+        let r: Raw = b"Basic QWxhZGRpbjo=".as_ref().into();
+        let auth: ProxyAuthorization<Basic> = Header::parse_header(&r).unwrap();
         assert_eq!(auth.0.username, "Aladdin");
         assert_eq!(auth.0.password, Some("".to_owned()));
     }
@@ -182,8 +183,8 @@ mod tests {
 
     #[test]
     fn test_bearer_auth_parse() {
-        let auth: ProxyAuthorization<Bearer> = Header::parse_header(
-            &b"Bearer fpKL54jvWmEGVoRdCNjG".as_ref().into()).unwrap();
+        let r: Raw = b"Bearer fpKL54jvWmEGVoRdCNjG".as_ref().into();
+        let auth: ProxyAuthorization<Bearer> = Header::parse_header(&r).unwrap();
         assert_eq!(auth.0.token, "fpKL54jvWmEGVoRdCNjG");
     }
 }

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::fmt;
 use std::str::{FromStr, from_utf8};
 use std::ops::{Deref, DerefMut};
-use header::{Header, Raw, Scheme};
+use header::{Header, RawLike, Scheme};
 
 /// `Proxy-Authorization` header, defined in [RFC7235](https://tools.ietf.org/html/rfc7235#section-4.4)
 ///
@@ -80,7 +80,9 @@ impl<S: Scheme + Any> Header for ProxyAuthorization<S> where <S as FromStr>::Err
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<ProxyAuthorization<S>> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<ProxyAuthorization<S>>
+    where T: RawLike<'a>
+    {
         if let Some(line) = raw.one() {
             let header = try!(from_utf8(line));
             if let Some(scheme) = <S as Scheme>::scheme() {

--- a/src/header/common/range.rs
+++ b/src/header/common/range.rs
@@ -273,118 +273,141 @@ impl Header for Range {
 
 }
 
-#[test]
-fn test_parse_bytes_range_valid() {
-    let r: Range = Header::parse_header(&"bytes=1-100".into()).unwrap();
-    let r2: Range = Header::parse_header(&"bytes=1-100,-".into()).unwrap();
-    let r3 =  Range::bytes(1, 100);
-    assert_eq!(r, r2);
-    assert_eq!(r2, r3);
+#[cfg(test)]
+mod tests {
+    use super::{ByteRangeSpec, Range};
+    use header::{Header, Raw};
 
-    let r: Range = Header::parse_header(&"bytes=1-100,200-".into()).unwrap();
-    let r2: Range = Header::parse_header(&"bytes= 1-100 , 101-xxx,  200- ".into()).unwrap();
-    let r3 =  Range::Bytes(
-        vec![ByteRangeSpec::FromTo(1, 100), ByteRangeSpec::AllFrom(200)]
-    );
-    assert_eq!(r, r2);
-    assert_eq!(r2, r3);
+    #[test]
+    fn test_parse_bytes_range_valid() {
+        let w: Raw = "bytes=1-100".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let w: Raw = "bytes=1-100,-".into();
+        let r2: Range = Header::parse_header(&w).unwrap();
+        let r3 = Range::bytes(1, 100);
+        assert_eq!(r, r2);
+        assert_eq!(r2, r3);
 
-    let r: Range = Header::parse_header(&"bytes=1-100,-100".into()).unwrap();
-    let r2: Range = Header::parse_header(&"bytes=1-100, ,,-100".into()).unwrap();
-    let r3 =  Range::Bytes(
-        vec![ByteRangeSpec::FromTo(1, 100), ByteRangeSpec::Last(100)]
-    );
-    assert_eq!(r, r2);
-    assert_eq!(r2, r3);
+        let w: Raw = "bytes=1-100,200-".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let w: Raw = "bytes= 1-100 , 101-xxx,  200- ".into();
+        let r2: Range = Header::parse_header(&w).unwrap();
+        let r3 =  Range::Bytes(
+            vec![ByteRangeSpec::FromTo(1, 100), ByteRangeSpec::AllFrom(200)]
+        );
+        assert_eq!(r, r2);
+        assert_eq!(r2, r3);
 
-    let r: Range = Header::parse_header(&"custom=1-100,-100".into()).unwrap();
-    let r2 =  Range::Unregistered("custom".to_owned(), "1-100,-100".to_owned());
-    assert_eq!(r, r2);
+        let w: Raw = "bytes=1-100,-100".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let w: Raw = "bytes=1-100, ,,-100".into();
+        let r2: Range = Header::parse_header(&w).unwrap();
+        let r3 =  Range::Bytes(
+            vec![ByteRangeSpec::FromTo(1, 100), ByteRangeSpec::Last(100)]
+        );
+        assert_eq!(r, r2);
+        assert_eq!(r2, r3);
 
-}
+        let w: Raw = "custom=1-100,-100".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let r2 =  Range::Unregistered("custom".to_owned(), "1-100,-100".to_owned());
+        assert_eq!(r, r2);
 
-#[test]
-fn test_parse_unregistered_range_valid() {
-    let r: Range = Header::parse_header(&"custom=1-100,-100".into()).unwrap();
-    let r2 =  Range::Unregistered("custom".to_owned(), "1-100,-100".to_owned());
-    assert_eq!(r, r2);
+    }
 
-    let r: Range = Header::parse_header(&"custom=abcd".into()).unwrap();
-    let r2 =  Range::Unregistered("custom".to_owned(), "abcd".to_owned());
-    assert_eq!(r, r2);
+    #[test]
+    fn test_parse_unregistered_range_valid() {
+        let w: Raw = "custom=1-100,-100".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let r2 =  Range::Unregistered("custom".to_owned(), "1-100,-100".to_owned());
+        assert_eq!(r, r2);
 
-    let r: Range = Header::parse_header(&"custom=xxx-yyy".into()).unwrap();
-    let r2 =  Range::Unregistered("custom".to_owned(), "xxx-yyy".to_owned());
-    assert_eq!(r, r2);
-}
+        let w: Raw = "custom=abcd".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let r2 =  Range::Unregistered("custom".to_owned(), "abcd".to_owned());
+        assert_eq!(r, r2);
 
-#[test]
-fn test_parse_invalid() {
-    let r: ::Result<Range> = Header::parse_header(&"bytes=1-a,-".into());
-    assert_eq!(r.ok(), None);
+        let w: Raw = "custom=xxx-yyy".into();
+        let r: Range = Header::parse_header(&w).unwrap();
+        let r2 =  Range::Unregistered("custom".to_owned(), "xxx-yyy".to_owned());
+        assert_eq!(r, r2);
+    }
 
-    let r: ::Result<Range> = Header::parse_header(&"bytes=1-2-3".into());
-    assert_eq!(r.ok(), None);
+    #[test]
+    fn test_parse_invalid() {
+        let w: Raw = "bytes=1-a,-".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
 
-    let r: ::Result<Range> = Header::parse_header(&"abc".into());
-    assert_eq!(r.ok(), None);
+        let w: Raw = "bytes=1-2-3".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
 
-    let r: ::Result<Range> = Header::parse_header(&"bytes=1-100=".into());
-    assert_eq!(r.ok(), None);
+        let w: Raw = "abc".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
 
-    let r: ::Result<Range> = Header::parse_header(&"bytes=".into());
-    assert_eq!(r.ok(), None);
+        let w: Raw = "bytes=1-100=".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
 
-    let r: ::Result<Range> = Header::parse_header(&"custom=".into());
-    assert_eq!(r.ok(), None);
+        let w: Raw = "bytes=".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
 
-    let r: ::Result<Range> = Header::parse_header(&"=1-100".into());
-    assert_eq!(r.ok(), None);
-}
+        let w: Raw = "custom=".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
 
-#[test]
-fn test_fmt() {
-    use header::Headers;
+        let w: Raw = "=1-100".into();
+        let r: ::Result<Range> = Header::parse_header(&w);
+        assert_eq!(r.ok(), None);
+    }
 
-    let mut headers = Headers::new();
+    #[test]
+    fn test_fmt() {
+        use header::Headers;
 
-    headers.set(
-        Range::Bytes(
-            vec![ByteRangeSpec::FromTo(0, 1000), ByteRangeSpec::AllFrom(2000)]
-    ));
-    assert_eq!(&headers.to_string(), "Range: bytes=0-1000,2000-\r\n");
+        let mut headers = Headers::new();
 
-    headers.clear();
-    headers.set(Range::Bytes(vec![]));
+        headers.set(
+            Range::Bytes(
+                vec![ByteRangeSpec::FromTo(0, 1000), ByteRangeSpec::AllFrom(2000)]
+            ));
+        assert_eq!(&headers.to_string(), "Range: bytes=0-1000,2000-\r\n");
 
-    assert_eq!(&headers.to_string(), "Range: bytes=\r\n");
+        headers.clear();
+        headers.set(Range::Bytes(vec![]));
 
-    headers.clear();
-    headers.set(Range::Unregistered("custom".to_owned(), "1-xxx".to_owned()));
+        assert_eq!(&headers.to_string(), "Range: bytes=\r\n");
 
-    assert_eq!(&headers.to_string(), "Range: custom=1-xxx\r\n");
-}
+        headers.clear();
+        headers.set(Range::Unregistered("custom".to_owned(), "1-xxx".to_owned()));
 
-#[test]
-fn test_byte_range_spec_to_satisfiable_range() {
-    assert_eq!(Some((0, 0)), ByteRangeSpec::FromTo(0, 0).to_satisfiable_range(3));
-    assert_eq!(Some((1, 2)), ByteRangeSpec::FromTo(1, 2).to_satisfiable_range(3));
-    assert_eq!(Some((1, 2)), ByteRangeSpec::FromTo(1, 5).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::FromTo(3, 3).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::FromTo(2, 1).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::FromTo(0, 0).to_satisfiable_range(0));
+        assert_eq!(&headers.to_string(), "Range: custom=1-xxx\r\n");
+    }
 
-    assert_eq!(Some((0, 2)), ByteRangeSpec::AllFrom(0).to_satisfiable_range(3));
-    assert_eq!(Some((2, 2)), ByteRangeSpec::AllFrom(2).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::AllFrom(3).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::AllFrom(5).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::AllFrom(0).to_satisfiable_range(0));
+    #[test]
+    fn test_byte_range_spec_to_satisfiable_range() {
+        assert_eq!(Some((0, 0)), ByteRangeSpec::FromTo(0, 0).to_satisfiable_range(3));
+        assert_eq!(Some((1, 2)), ByteRangeSpec::FromTo(1, 2).to_satisfiable_range(3));
+        assert_eq!(Some((1, 2)), ByteRangeSpec::FromTo(1, 5).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::FromTo(3, 3).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::FromTo(2, 1).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::FromTo(0, 0).to_satisfiable_range(0));
 
-    assert_eq!(Some((1, 2)), ByteRangeSpec::Last(2).to_satisfiable_range(3));
-    assert_eq!(Some((2, 2)), ByteRangeSpec::Last(1).to_satisfiable_range(3));
-    assert_eq!(Some((0, 2)), ByteRangeSpec::Last(5).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::Last(0).to_satisfiable_range(3));
-    assert_eq!(None, ByteRangeSpec::Last(2).to_satisfiable_range(0));
+        assert_eq!(Some((0, 2)), ByteRangeSpec::AllFrom(0).to_satisfiable_range(3));
+        assert_eq!(Some((2, 2)), ByteRangeSpec::AllFrom(2).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::AllFrom(3).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::AllFrom(5).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::AllFrom(0).to_satisfiable_range(0));
+
+        assert_eq!(Some((1, 2)), ByteRangeSpec::Last(2).to_satisfiable_range(3));
+        assert_eq!(Some((2, 2)), ByteRangeSpec::Last(1).to_satisfiable_range(3));
+        assert_eq!(Some((0, 2)), ByteRangeSpec::Last(5).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::Last(0).to_satisfiable_range(3));
+        assert_eq!(None, ByteRangeSpec::Last(2).to_satisfiable_range(0));
+    }
 }
 
 bench_header!(bytes_multi, Range, { vec![b"bytes=1-1001,2001-3001,10001-".to_vec()]});

--- a/src/header/common/range.rs
+++ b/src/header/common/range.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use header::parsing::{from_one_raw_str};
 
 /// `Range` header, defined in [RFC7233](https://tools.ietf.org/html/rfc7233#section-3.1)
@@ -261,7 +261,9 @@ impl Header for Range {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Range> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Range>
+    where T: RawLike<'a>
+    {
         from_one_raw_str(raw)
     }
 

--- a/src/header/common/referrer_policy.rs
+++ b/src/header/common/referrer_policy.rs
@@ -106,18 +106,28 @@ impl fmt::Display for ReferrerPolicy {
     }
 }
 
-#[test]
-fn test_parse_header() {
-    let a: ReferrerPolicy = Header::parse_header(&"origin".into()).unwrap();
-    let b = ReferrerPolicy::Origin;
-    assert_eq!(a, b);
-    let e: ::Result<ReferrerPolicy> = Header::parse_header(&"foobar".into());
-    assert!(e.is_err());
-}
+#[cfg(test)]
+mod tests {
+    use super::ReferrerPolicy;
+    use header::{Header, Raw};
 
-#[test]
-fn test_rightmost_header() {
-    let a: ReferrerPolicy = Header::parse_header(&"same-origin, origin, foobar".into()).unwrap();
-    let b = ReferrerPolicy::Origin;
-    assert_eq!(a, b);
+    #[test]
+    fn test_parse_header() {
+        let r: Raw = "origin".into();
+        let a: ReferrerPolicy = Header::parse_header(&r).unwrap();
+        let b = ReferrerPolicy::Origin;
+        assert_eq!(a, b);
+
+        let r: Raw = "foobar".into();
+        let e: ::Result<ReferrerPolicy> = Header::parse_header(&r);
+        assert!(e.is_err());
+    }
+
+    #[test]
+    fn test_rightmost_header() {
+        let r: Raw = "same-origin, origin, foobar".into();
+        let a: ReferrerPolicy = Header::parse_header(&r).unwrap();
+        let b = ReferrerPolicy::Origin;
+        assert_eq!(a, b);
+    }
 }

--- a/src/header/common/referrer_policy.rs
+++ b/src/header/common/referrer_policy.rs
@@ -2,7 +2,7 @@ use std::fmt;
 #[allow(unused, deprecated)]
 use std::ascii::AsciiExt;
 
-use header::{Header, Raw, parsing};
+use header::{Header, RawLike, parsing};
 
 /// `Referrer-Policy` header, part of
 /// [Referrer Policy](https://www.w3.org/TR/referrer-policy/#referrer-policy-header)
@@ -60,7 +60,9 @@ impl Header for ReferrerPolicy {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<ReferrerPolicy> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<ReferrerPolicy>
+    where T: RawLike<'a>
+    {
         use self::ReferrerPolicy::*;
         // See https://www.w3.org/TR/referrer-policy/#determine-policy-for-token
         let headers: Vec<String> = try!(parsing::from_comma_delimited(raw));

--- a/src/header/common/retry_after.rs
+++ b/src/header/common/retry_after.rs
@@ -134,7 +134,7 @@ impl fmt::Display for RetryAfter {
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-    use header::Header;
+    use header::{Header, Raw};
     use header::shared::HttpDate;
 
     use super::RetryAfter;
@@ -146,8 +146,8 @@ mod tests {
 
     #[test]
     fn parse_delay() {
-        let retry_after = RetryAfter::parse_header(&vec![b"1234".to_vec()].into()).unwrap();
-
+        let r: Raw = vec![b"1234".to_vec()].into();
+        let retry_after = RetryAfter::parse_header(&r).unwrap();
         assert_eq!(RetryAfter::Delay(Duration::from_secs(1234)), retry_after);
     }
 
@@ -156,8 +156,8 @@ mod tests {
             #[test]
             fn $name() {
                 let dt = "Sun, 06 Nov 1994 08:49:37 GMT".parse::<HttpDate>().unwrap();
-                let retry_after = RetryAfter::parse_header(&vec![$bytes.to_vec()].into()).expect("parse_header ok");
-
+                let r: Raw = vec![$bytes.to_vec()].into();
+                let retry_after = RetryAfter::parse_header(&r).expect("parse_header ok");
                 assert_eq!(RetryAfter::DateTime(dt), retry_after);
             }
         }
@@ -169,15 +169,16 @@ mod tests {
 
     #[test]
     fn hyper_headers_from_raw_delay() {
-        let retry_after = RetryAfter::parse_header(&b"300".to_vec().into()).unwrap();
+        let r: Raw = b"300".to_vec().into();
+        let retry_after = RetryAfter::parse_header(&r).unwrap();
         assert_eq!(retry_after, RetryAfter::Delay(Duration::from_secs(300)));
     }
 
     #[test]
     fn hyper_headers_from_raw_datetime() {
-        let retry_after = RetryAfter::parse_header(&b"Sun, 06 Nov 1994 08:49:37 GMT".to_vec().into()).unwrap();
+        let r: Raw = b"Sun, 06 Nov 1994 08:49:37 GMT".to_vec().into();
+        let retry_after = RetryAfter::parse_header(&r).unwrap();
         let expected = "Sun, 06 Nov 1994 08:49:37 GMT".parse::<HttpDate>().unwrap();
-
         assert_eq!(retry_after, RetryAfter::DateTime(expected));
     }
 }

--- a/src/header/common/retry_after.rs
+++ b/src/header/common/retry_after.rs
@@ -38,7 +38,7 @@
 use std::fmt;
 use std::time::Duration;
 
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use header::shared::HttpDate;
 
 /// The `Retry-After` header.
@@ -90,7 +90,9 @@ impl Header for RetryAfter {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<RetryAfter> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<RetryAfter>
+    where T: RawLike<'a>
+    {
         if let Some(ref line) = raw.one() {
             let utf8_str = match ::std::str::from_utf8(line) {
                 Ok(utf8_str) => utf8_str,

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -1,4 +1,4 @@
-use header::{Header, Raw};
+use header::{Header, RawLike};
 use std::fmt;
 use std::str::from_utf8;
 
@@ -79,9 +79,11 @@ impl Header for SetCookie {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<SetCookie> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<SetCookie>
+    where T: RawLike<'a>
+    {
         let mut set_cookies = Vec::with_capacity(raw.len());
-        for set_cookies_raw in raw {
+        for set_cookies_raw in raw.iter() {
             if let Ok(s) = from_utf8(&set_cookies_raw[..]) {
                 set_cookies.push(s.trim().to_owned());
             }

--- a/src/header/common/strict_transport_security.rs
+++ b/src/header/common/strict_transport_security.rs
@@ -151,53 +151,61 @@ impl fmt::Display for StrictTransportSecurity {
 #[cfg(test)]
 mod tests {
     use super::StrictTransportSecurity;
-    use header::Header;
+    use header::{Header, Raw};
 
     #[test]
     fn test_parse_max_age() {
-        let h = Header::parse_header(&"max-age=31536000".into());
+        let r: Raw = "max-age=31536000".into();
+        let h = Header::parse_header(&r);
         assert_eq!(h.ok(), Some(StrictTransportSecurity { include_subdomains: false, max_age: 31536000u64 }));
     }
 
     #[test]
     fn test_parse_max_age_no_value() {
-        let h: ::Result<StrictTransportSecurity> = Header::parse_header(&"max-age".into());
+        let r: Raw = "max-age".into();
+        let h: ::Result<StrictTransportSecurity> = Header::parse_header(&r);
         assert!(h.is_err());
     }
 
     #[test]
     fn test_parse_quoted_max_age() {
-        let h = Header::parse_header(&"max-age=\"31536000\"".into());
+        let r: Raw = "max-age=\"31536000\"".into();
+        let h = Header::parse_header(&r);
         assert_eq!(h.ok(), Some(StrictTransportSecurity { include_subdomains: false, max_age: 31536000u64 }));
     }
 
     #[test]
     fn test_parse_spaces_max_age() {
-        let h = Header::parse_header(&"max-age = 31536000".into());
+        let r: Raw = "max-age = 31536000".into();
+        let h = Header::parse_header(&r);
         assert_eq!(h.ok(), Some(StrictTransportSecurity { include_subdomains: false, max_age: 31536000u64 }));
     }
 
     #[test]
     fn test_parse_include_subdomains() {
-        let h = Header::parse_header(&"max-age=15768000 ; includeSubDomains".into());
+        let r: Raw = "max-age=15768000 ; includeSubDomains".into();
+        let h = Header::parse_header(&r);
         assert_eq!(h.ok(), Some(StrictTransportSecurity { include_subdomains: true, max_age: 15768000u64 }));
     }
 
     #[test]
     fn test_parse_no_max_age() {
-        let h: ::Result<StrictTransportSecurity> = Header::parse_header(&"includeSubDomains".into());
+        let r: Raw = "includeSubDomains".into();
+        let h: ::Result<StrictTransportSecurity> = Header::parse_header(&r);
         assert!(h.is_err());
     }
 
     #[test]
     fn test_parse_max_age_nan() {
-        let h: ::Result<StrictTransportSecurity> = Header::parse_header(&"max-age = derp".into());
+        let r: Raw = "max-age = derp".into();
+        let h: ::Result<StrictTransportSecurity> = Header::parse_header(&r);
         assert!(h.is_err());
     }
 
     #[test]
     fn test_parse_duplicate_directives() {
-        assert!(StrictTransportSecurity::parse_header(&"max-age=100; max-age=5; max-age=0".into()).is_err());
+        let r: Raw = "max-age=100; max-age=5; max-age=0".into();
+        assert!(StrictTransportSecurity::parse_header(&r).is_err());
     }
 }
 

--- a/src/header/common/strict_transport_security.rs
+++ b/src/header/common/strict_transport_security.rs
@@ -3,7 +3,7 @@ use std::str::{self, FromStr};
 
 use unicase;
 
-use header::{Header, Raw, parsing};
+use header::{Header, RawLike, parsing};
 
 /// `StrictTransportSecurity` header, defined in [RFC6797](https://tools.ietf.org/html/rfc6797)
 ///
@@ -127,7 +127,9 @@ impl Header for StrictTransportSecurity {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<StrictTransportSecurity> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<StrictTransportSecurity>
+    where T: RawLike<'a>
+    {
         parsing::from_one_raw_str(raw)
     }
 

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -72,7 +72,8 @@ header! {
             Some(Upgrade(vec![Protocol::new(ProtocolName::WebSocket, None)])));
         #[test]
         fn test3() {
-            let x: ::Result<Upgrade> = Header::parse_header(&"WEbSOCKet".into());
+            let r: Raw = "WEbSOCKet".into();
+            let x: ::Result<Upgrade> = Header::parse_header(&r);
             assert_eq!(x.ok(), Some(Upgrade(vec![Protocol::new(ProtocolName::WebSocket, None)])));
         }
     }

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -57,14 +57,19 @@ header! {
         #[test]
         fn test2() {
             let mut vary: ::Result<Vary>;
-
-            vary = Header::parse_header(&"*".into());
+            let r: Raw = "*".into();
+            vary = Header::parse_header(&r);
             assert_eq!(vary.ok(), Some(Vary::Any));
 
-            vary = Header::parse_header(&"etag,cookie,allow".into());
-            assert_eq!(vary.ok(), Some(Vary::Items(vec!["eTag".parse().unwrap(),
-                                                        "cookIE".parse().unwrap(),
-                                                        "AlLOw".parse().unwrap(),])));
+            let r: Raw = "etag,cookie,allow".into();
+            vary = Header::parse_header(&r);
+            assert_eq!(
+                vary.ok(),
+                Some(Vary::Items(vec![
+                    "eTag".parse().unwrap(),
+                    "cookIE".parse().unwrap(),
+                    "AlLOw".parse().unwrap(),
+                ])));
         }
     }
 }

--- a/src/header/common/warning.rs
+++ b/src/header/common/warning.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::str::{FromStr};
-use header::{Header, HttpDate, Raw};
+use header::{Header, HttpDate, RawLike};
 use header::parsing::from_one_raw_str;
 
 /// `Warning` header, defined in [RFC7234](https://tools.ietf.org/html/rfc7234#section-5.5)
@@ -94,7 +94,9 @@ impl Header for Warning {
         NAME
     }
 
-    fn parse_header(raw: &Raw) -> ::Result<Warning> {
+    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Warning>
+    where T: RawLike<'a>
+    {
         from_one_raw_str(raw)
     }
 

--- a/src/header/common/warning.rs
+++ b/src/header/common/warning.rs
@@ -153,11 +153,14 @@ impl FromStr for Warning {
 #[cfg(test)]
 mod tests {
     use super::Warning;
-    use header::{Header, HttpDate};
+    use header::{Header, HttpDate, Raw};
 
     #[test]
     fn test_parsing() {
-        let warning = Header::parse_header(&vec![b"112 - \"network down\" \"Sat, 25 Aug 2012 23:34:45 GMT\"".to_vec()].into());
+        let r: Raw = vec![
+            b"112 - \"network down\" \"Sat, 25 Aug 2012 23:34:45 GMT\"".to_vec()
+        ].into();
+        let warning = Header::parse_header(&r);
         assert_eq!(warning.ok(), Some(Warning {
             code: 112,
             agent: "-".to_owned(),
@@ -165,7 +168,11 @@ mod tests {
             date: "Sat, 25 Aug 2012 23:34:45 GMT".parse::<HttpDate>().ok()
         }));
 
-        let warning = Header::parse_header(&vec![b"299 api.hyper.rs:8080 \"Deprecated API : use newapi.hyper.rs instead.\"".to_vec()].into());
+        let r: Raw = vec![
+            b"299 api.hyper.rs:8080 \"Deprecated API : \
+              use newapi.hyper.rs instead.\"".to_vec()
+        ].into();
+        let warning = Header::parse_header(&r);
         assert_eq!(warning.ok(), Some(Warning {
             code: 299,
             agent: "api.hyper.rs:8080".to_owned(),
@@ -173,7 +180,12 @@ mod tests {
             date: None
         }));
 
-        let warning = Header::parse_header(&vec![b"299 api.hyper.rs:8080 \"Deprecated API : use newapi.hyper.rs instead.\" \"Tue, 15 Nov 1994 08:12:31 GMT\"".to_vec()].into());
+        let r: Raw = vec![
+            b"299 api.hyper.rs:8080 \"Deprecated API : \
+              use newapi.hyper.rs instead.\" \
+              \"Tue, 15 Nov 1994 08:12:31 GMT\"".to_vec()
+        ].into();
+        let warning = Header::parse_header(&r);
         assert_eq!(warning.ok(), Some(Warning {
             code: 299,
             agent: "api.hyper.rs:8080".to_owned(),

--- a/src/header/internals/item.rs
+++ b/src/header/internals/item.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::str::from_utf8;
 
 use super::cell::{OptCell, PtrMapCell};
-use header::{Header, Formatter, Multi, raw, Raw};
+use header::{Header, Formatter, Multi, raw, Raw, RawLike};
 
 
 #[derive(Clone)]

--- a/src/header/internals/item.rs
+++ b/src/header/internals/item.rs
@@ -6,7 +6,6 @@ use std::str::from_utf8;
 use super::cell::{OptCell, PtrMapCell};
 use header::{Header, Formatter, Multi, raw, Raw, RawLike};
 
-
 #[derive(Clone)]
 pub struct Item {
     raw: OptCell<Raw>,
@@ -23,7 +22,6 @@ impl Item {
     }
 
     #[inline]
-
     pub fn new_typed<H: Header>(val: H) -> Item {
         Item {
             raw: OptCell::new(None),

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -139,7 +139,7 @@ use self::sealed::HeaderClone;
 
 pub use self::shared::*;
 pub use self::common::*;
-pub use self::raw::{Raw, RawLike};
+pub use self::raw::{Raw, RawLike, ValueMapIter};
 use bytes::Bytes;
 
 mod common;

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -1132,6 +1132,36 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[bench]
+    #[cfg(feature = "compat")]
+    fn bench_compat_value_parse(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            ContentEncoding::parse_header(&val).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    #[cfg(feature = "compat")]
+    fn bench_compat_value_parse_str(b: &mut Bencher) {
+        use http;
+        use header::Raw;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            let r: Raw = val.to_str().unwrap().into();
+            ContentEncoding::parse_header(&r).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
     fn bench_headers_new(b: &mut Bencher) {
         b.iter(|| {
             let mut h = Headers::new();

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -1146,7 +1146,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     #[cfg(feature = "compat")]
-    fn bench_compat_value_parse_str(b: &mut Bencher) {
+    fn bench_compat_value_parse_extra_str(b: &mut Bencher) {
         use http;
         use header::Raw;
         let mut hheads = http::HeaderMap::new();
@@ -1156,6 +1156,19 @@ mod tests {
             let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
             let r: Raw = val.to_str().unwrap().into();
             ContentEncoding::parse_header(&r).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    #[cfg(feature = "compat")]
+    fn bench_compat_value_parse_int(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_LENGTH, "1024".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_LENGTH).unwrap();
+            ContentLength::parse_header(&val).unwrap();
         })
     }
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -139,7 +139,11 @@ use self::sealed::HeaderClone;
 
 pub use self::shared::*;
 pub use self::common::*;
-pub use self::raw::{Raw, RawLike, ValueMapIter};
+pub use self::raw::{Raw, RawLike};
+
+#[cfg(feature = "compat")]
+pub use self::raw::{ValueMapIter};
+
 use bytes::Bytes;
 
 mod common;

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -182,7 +182,6 @@ pub trait Header: 'static + HeaderClone + Send + Sync {
     /// The main example here is `Set-Cookie`, which requires that every
     /// cookie being set be specified in a separate line. Almost every other
     /// case should only format as 1 single line.
-    #[inline]
     fn fmt_header(&self, f: &mut Formatter) -> fmt::Result;
 }
 

--- a/src/header/parsing.rs
+++ b/src/header/parsing.rs
@@ -6,12 +6,14 @@ use std::str::FromStr;
 use std::fmt::{self, Display};
 use percent_encoding;
 
-use header::Raw;
+use header::RawLike;
 use header::shared::Charset;
 
 
 /// Reads a single raw string when parsing a header.
-pub fn from_one_raw_str<T: str::FromStr>(raw: &Raw) -> ::Result<T> {
+pub fn from_one_raw_str<'a, R, T>(raw: &'a R) -> ::Result<T>
+where R: RawLike<'a>, T: str::FromStr
+{
     if let Some(line) = raw.one() {
         if !line.is_empty() {
             return from_raw_str(line)
@@ -28,9 +30,11 @@ pub fn from_raw_str<T: str::FromStr>(raw: &[u8]) -> ::Result<T> {
 
 /// Reads a comma-delimited raw header into a Vec.
 #[inline]
-pub fn from_comma_delimited<T: str::FromStr>(raw: &Raw) -> ::Result<Vec<T>> {
+pub fn from_comma_delimited<'a, R, T>(raw: &'a R) -> ::Result<Vec<T>>
+where R: RawLike<'a>, T: str::FromStr
+{
     let mut result = Vec::new();
-    for s in raw {
+    for s in raw.iter() {
         let s = try!(str::from_utf8(s.as_ref()));
         result.extend(s.split(',')
                       .filter_map(|x| match x.trim() {

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -5,8 +5,8 @@ use bytes::Bytes;
 #[cfg(feature = "compat")]
 use http::header::{GetAll, HeaderValue, ValueIter};
 
-/// Trait for raw bytes access to header values (aka lines) for a single
-/// key, for a parsing purposes.
+/// Trait for raw bytes parsing access to header values (aka lines) for a single
+/// header name.
 pub trait RawLike<'a> {
     /// The associated type of `Iterator` over values.
     type IntoIter: Iterator<Item=&'a [u8]> + 'a;

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -251,7 +251,7 @@ impl<'a> RawLike<'a> for GetAll<'a, HeaderValue> {
 
 #[cfg(feature = "compat")]
 impl<'a> RawLike<'a> for &'a HeaderValue {
-    type IntoIter = std::iter::Once<&'a [u8]>;
+    type IntoIter = ::std::iter::Once<&'a [u8]>;
 
     fn len(&'a self) -> usize {
         1
@@ -262,7 +262,7 @@ impl<'a> RawLike<'a> for &'a HeaderValue {
     }
 
     fn iter(&'a self) -> Self::IntoIter {
-        std::iter::once(self.as_bytes())
+        ::std::iter::once(self.as_bytes())
     }
 }
 

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -7,8 +7,7 @@ use http::header::{GetAll, HeaderValue, ValueIter};
 
 /// Trait for raw bytes access to header values (aka lines) for a single
 /// key, for a parsing purposes.
-pub trait RawLike<'a>
-{
+pub trait RawLike<'a> {
     /// The associated type of `Iterator` over values.
     type IntoIter: Iterator<Item=&'a [u8]> + 'a;
 
@@ -59,8 +58,7 @@ impl Raw {
     }
 }
 
-impl<'a> RawLike<'a> for Raw
-{
+impl<'a> RawLike<'a> for Raw {
     type IntoIter = RawLines<'a>;
 
     #[inline]
@@ -229,8 +227,7 @@ impl<'a> Iterator for ValueMapIter<'a> {
 }
 
 #[cfg(feature = "compat")]
-impl<'a> RawLike<'a> for GetAll<'a, HeaderValue>
-{
+impl<'a> RawLike<'a> for GetAll<'a, HeaderValue> {
     type IntoIter = ValueMapIter<'a>;
 
     fn len(&'a self) -> usize {
@@ -253,8 +250,7 @@ impl<'a> RawLike<'a> for GetAll<'a, HeaderValue>
 }
 
 #[cfg(feature = "compat")]
-impl<'a> RawLike<'a> for &'a HeaderValue
-{
+impl<'a> RawLike<'a> for &'a HeaderValue {
     type IntoIter = std::iter::Once<&'a [u8]>;
 
     fn len(&'a self) -> usize {

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -2,6 +2,22 @@ use std::borrow::Cow;
 use std::fmt;
 use bytes::Bytes;
 
+/// Trait for Raw access for parsing
+pub trait RawLike<'a>
+{
+    /// The associated concrete type of iterator
+    type IntoIter: Iterator<Item=&'a [u8]> + 'a;
+
+    /// Returns the amount of lines.
+    fn len(&'a self) -> usize;
+
+    /// Returns the line if there is only 1.
+    fn one(&'a self) -> Option<&'a [u8]>;
+
+    /// Iterate the lines of raw bytes.
+    fn iter(&'a self) -> Self::IntoIter;
+}
+
 /// A raw header value.
 #[derive(Clone, Debug)]
 pub struct Raw(Lines);
@@ -64,6 +80,24 @@ impl Raw {
                 self.0 = Lines::Many(lines);
             }
         }
+    }
+}
+
+impl<'a> RawLike<'a> for Raw
+{
+    type IntoIter = RawLines<'a>;
+
+    fn len(&'a self) -> usize {
+        self.len()
+    }
+
+    fn one(&'a self) -> Option<&'a [u8]> {
+        self.one()
+    }
+
+    fn iter(&'a self) -> RawLines<'a>
+    {
+        self.iter()
     }
 }
 

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -2,6 +2,9 @@ use std::borrow::Cow;
 use std::fmt;
 use bytes::Bytes;
 
+#[cfg(feature = "compat")]
+use http::header::{GetAll, HeaderValue, ValueIter};
+
 /// Trait for Raw access for parsing
 pub trait RawLike<'a>
 {
@@ -222,6 +225,62 @@ impl From<Bytes> for Raw {
     #[inline]
     fn from(val: Bytes) -> Raw {
         Raw(Lines::One(val))
+    }
+}
+
+/// Iterator adaptor for HeaderValue
+#[cfg(feature = "compat")]
+#[derive(Debug)]
+pub struct ValueMapIter<'a>(ValueIter<'a, HeaderValue>);
+
+#[cfg(feature = "compat")]
+impl<'a> Iterator for ValueMapIter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(HeaderValue::as_bytes)
+    }
+}
+
+#[cfg(feature = "compat")]
+impl<'a> RawLike<'a> for GetAll<'a, HeaderValue>
+{
+    type IntoIter = ValueMapIter<'a>;
+
+    fn len(&'a self) -> usize {
+        self.iter().count()
+    }
+
+    fn one(&'a self) -> Option<&'a [u8]> {
+        let mut iter = self.iter();
+        if let Some(v) = iter.next() {
+            if iter.next().is_none() {
+                return Some(v.as_bytes());
+            }
+        }
+        None
+    }
+
+    fn iter(&'a self) -> ValueMapIter<'a> {
+        ValueMapIter(self.iter())
+    }
+}
+
+#[cfg(feature = "compat")]
+impl<'a> RawLike<'a> for &'a HeaderValue
+{
+    type IntoIter = std::iter::Once<&'a [u8]>;
+
+    fn len(&'a self) -> usize {
+        1
+    }
+
+    fn one(&'a self) -> Option<&'a [u8]> {
+        Some(self.as_bytes())
+    }
+
+    fn iter(&'a self) -> Self::IntoIter {
+        std::iter::once(self.as_bytes())
     }
 }
 

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -26,35 +26,6 @@ pub trait RawLike<'a>
 pub struct Raw(Lines);
 
 impl Raw {
-    /// Returns the amount of lines.
-    #[inline]
-    pub fn len(&self) -> usize {
-        match self.0 {
-            Lines::Empty => 0,
-            Lines::One(..) => 1,
-            Lines::Many(ref lines) => lines.len()
-        }
-    }
-
-    /// Returns the line if there is only 1.
-    #[inline]
-    pub fn one(&self) -> Option<&[u8]> {
-        match self.0 {
-            Lines::One(ref line) => Some(line.as_ref()),
-            Lines::Many(ref lines) if lines.len() == 1 => Some(lines[0].as_ref()),
-            _ => None
-        }
-    }
-
-    /// Iterate the lines of raw bytes.
-    #[inline]
-    pub fn iter(&self) -> RawLines {
-        RawLines {
-            inner: &self.0,
-            pos: 0,
-        }
-    }
-
     /// Append a line to this `Raw` header value.
     pub fn push<V: Into<Raw>>(&mut self, val: V) {
         let raw = val.into();
@@ -90,17 +61,30 @@ impl<'a> RawLike<'a> for Raw
 {
     type IntoIter = RawLines<'a>;
 
+    #[inline]
     fn len(&'a self) -> usize {
-        self.len()
+        match self.0 {
+            Lines::Empty => 0,
+            Lines::One(..) => 1,
+            Lines::Many(ref lines) => lines.len()
+        }
     }
 
+    #[inline]
     fn one(&'a self) -> Option<&'a [u8]> {
-        self.one()
+        match self.0 {
+            Lines::One(ref line) => Some(line.as_ref()),
+            Lines::Many(ref lines) if lines.len() == 1 => Some(lines[0].as_ref()),
+            _ => None
+        }
     }
 
-    fn iter(&'a self) -> RawLines<'a>
-    {
-        self.iter()
+    #[inline]
+    fn iter(&'a self) -> RawLines<'a> {
+        RawLines {
+            inner: &self.0,
+            pos: 0,
+        }
     }
 }
 

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -5,19 +5,21 @@ use bytes::Bytes;
 #[cfg(feature = "compat")]
 use http::header::{GetAll, HeaderValue, ValueIter};
 
-/// Trait for Raw access for parsing
+/// Trait for raw bytes access to header values (aka lines) for a single
+/// key, for a parsing purposes.
 pub trait RawLike<'a>
 {
-    /// The associated concrete type of iterator
+    /// The associated type of `Iterator` over values.
     type IntoIter: Iterator<Item=&'a [u8]> + 'a;
 
-    /// Returns the amount of lines.
+    /// Return the number of values (lines) in the headers.
     fn len(&'a self) -> usize;
 
-    /// Returns the line if there is only 1.
+    /// Return the single value (line), if and only if there is exactly
+    /// one. Otherwise return `None`.
     fn one(&'a self) -> Option<&'a [u8]>;
 
-    /// Iterate the lines of raw bytes.
+    /// Iterate the values (lines) as raw bytes.
     fn iter(&'a self) -> Self::IntoIter;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //! dependencies, for continued use with hyper 0.12 (current master), where
 //! this module was removed in preference to the byte-oriented `http::header`
 //! module.
+//!
+//! See the [*header*](header/index.html) module for more details.
 
 extern crate base64;
 extern crate bytes;


### PR DESCRIPTION
This is a more aggressive, breaking alternative to #7, which avoids an allocation when parsing (typed) headers from `HeaderMap`, `HeaderValue`(s), by changing the signature of `Header::parse_header` to:
``` rust
    fn parse_header<'a, T>(raw: &'a T) -> ::Result<Self>
    where T: RawLike<'a>, Self: Sized;
```
…and implementing `RawLike` for `Raw`, `HeaderValue` and (`HeaderMap::get_all`) `GetAll`.  

#### Expected breakage

Any 3rd-party custom headers directly implementing `parse_header` would need to change accordingly on upgrade. Also `into` conversions to `Raw` now frequently need to be type annotated, as exhibited by test changes in this PR.  

#### Benchmarks

In the following comparative benchmarks, "parse" is parsing a comma delimited, text header value. "parse_extra_str" adds a needless string copy (and extra utf8 check), which is expected to be a common mistake with the current `Raw` interface.  "parse_int" parses the integer Content-Length header. 

Branch raw-from-header-value-conversions (PR #7):
```
test header::tests::bench_compat_value_parse_extra_str ... bench: 230 ns/iter (+/- 7)
test header::tests::bench_compat_value_parse           ... bench: 198 ns/iter (+/- 48)
test header::tests::bench_compat_value_parse_int       ... bench:  50 ns/iter (+/- 3)
```
This branch (PR):
```txt
test header::tests::bench_compat_value_parse_extra_str ... bench: 230 ns/iter (+/- 4)
test header::tests::bench_compat_value_parse           ... bench: 172 ns/iter (+/- 6)
test header::tests::bench_compat_value_parse_int       ... bench:  32 ns/iter (+/- 2)
```
Also there is no observed regression on the existing `Raw`-based `*::bench_parse` benchmarks with these changes. 

(All bench results on rustc 1.33.0-nightly (93c2f055b 2018-12-15), i7-5600U dev host.)


