### PR TITLE
Add TypedHeaders extension trait for HeaderMap

### DIFF
--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -145,3 +145,5 @@ impl Accept {
 
 
 bench_header!(bench, Accept, { vec![b"text/plain; q=0.5, text/html".to_vec()] });
+
+standard_header!(Accept, ACCEPT);

--- a/src/header/common/accept_charset.rs
+++ b/src/header/common/accept_charset.rs
@@ -55,3 +55,5 @@ header! {
         test_header!(test1, vec![b"iso-8859-5, unicode-1-1;q=0.8"]);
     }
 }
+
+standard_header!(AcceptCharset, ACCEPT_CHARSET);

--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -70,3 +70,5 @@ header! {
         test_header!(test5, vec![b"gzip, identity; q=0.5, *;q=0"]);
     }
 }
+
+standard_header!(AcceptEncoding, ACCEPT_ENCODING);

--- a/src/header/common/accept_language.rs
+++ b/src/header/common/accept_language.rs
@@ -70,3 +70,5 @@ header! {
 
 bench_header!(bench, AcceptLanguage,
               { vec![b"en-us;q=1.0, en;q=0.5, fr".to_vec()] });
+
+standard_header!(AcceptLanguage, ACCEPT_LANGUAGE);

--- a/src/header/common/accept_ranges.rs
+++ b/src/header/common/accept_ranges.rs
@@ -103,3 +103,5 @@ impl Display for RangeUnit {
         }
     }
 }
+
+standard_header!(AcceptRanges, ACCEPT_RANGES);

--- a/src/header/common/access_control_allow_credentials.rs
+++ b/src/header/common/access_control_allow_credentials.rs
@@ -89,3 +89,5 @@ mod test_access_control_allow_credentials {
     test_header!(only_single,  vec![b"true", b"true"], None);
     test_header!(no_gibberish, vec!["\u{645}\u{631}\u{62d}\u{628}\u{627}".as_bytes()], None);
 }
+
+standard_header!(AccessControlAllowCredentials, ACCESS_CONTROL_ALLOW_CREDENTIALS);

--- a/src/header/common/access_control_allow_headers.rs
+++ b/src/header/common/access_control_allow_headers.rs
@@ -59,3 +59,5 @@ header! {
         test_header!(test1, vec![b"accept-language, date"]);
     }
 }
+
+standard_header!(AccessControlAllowHeaders, ACCESS_CONTROL_ALLOW_HEADERS);

--- a/src/header/common/access_control_allow_methods.rs
+++ b/src/header/common/access_control_allow_methods.rs
@@ -49,3 +49,5 @@ header! {
         test_header!(test1, vec![b"PUT, DELETE, XMODIFY"]);
     }
 }
+
+standard_header!(AccessControlAllowMethods, ACCESS_CONTROL_ALLOW_METHODS);

--- a/src/header/common/access_control_allow_origin.rs
+++ b/src/header/common/access_control_allow_origin.rs
@@ -98,3 +98,5 @@ mod test_access_control_allow_origin {
     test_header!(test2, vec![b"*"]);
     test_header!(test3, vec![b"http://google.com/"]);
 }
+
+standard_header!(AccessControlAllowOrigin, ACCESS_CONTROL_ALLOW_ORIGIN);

--- a/src/header/common/access_control_expose_headers.rs
+++ b/src/header/common/access_control_expose_headers.rs
@@ -61,3 +61,5 @@ header! {
         test_header!(test1, vec![b"etag, content-length"]);
     }
 }
+
+standard_header!(AccessControlExposeHeaders, ACCESS_CONTROL_EXPOSE_HEADERS);

--- a/src/header/common/access_control_max_age.rs
+++ b/src/header/common/access_control_max_age.rs
@@ -29,3 +29,5 @@ header! {
         test_header!(test1, vec![b"531"]);
     }
 }
+
+standard_header!(AccessControlMaxAge, ACCESS_CONTROL_MAX_AGE);

--- a/src/header/common/access_control_request_headers.rs
+++ b/src/header/common/access_control_request_headers.rs
@@ -59,3 +59,5 @@ header! {
         test_header!(test1, vec![b"accept-language, date"]);
     }
 }
+
+standard_header!(AccessControlRequestHeaders, ACCESS_CONTROL_REQUEST_HEADERS);

--- a/src/header/common/access_control_request_method.rs
+++ b/src/header/common/access_control_request_method.rs
@@ -30,3 +30,5 @@ header! {
         test_header!(test1, vec![b"GET"]);
     }
 }
+
+standard_header!(AccessControlRequestMethod, ACCESS_CONTROL_REQUEST_METHOD);

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -77,3 +77,5 @@ header! {
 
 bench_header!(bench,
     Allow, { vec![b"OPTIONS,GET,PUT,POST,DELETE,HEAD,TRACE,CONNECT,PATCH,fOObAr".to_vec()] });
+
+standard_header!(Allow, ALLOW);

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -303,7 +303,7 @@ bench_header!(bearer, Authorization<Bearer>, { vec![b"Bearer fpKL54jvWmEGVoRdCNj
 
 #[cfg(feature = "compat")]
 impl<S> ::header::StandardHeader for Authorization<S>
-    where S: Scheme + Any + ::std::string::ToString
+    where S: Scheme + Any + ::std::fmt::Display
 {
     #[inline]
     fn http_header_name() -> ::http::header::HeaderName {

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -300,3 +300,13 @@ mod tests {
 bench_header!(raw, Authorization<String>, { vec![b"foo bar baz".to_vec()] });
 bench_header!(basic, Authorization<Basic>, { vec![b"Basic QWxhZGRpbjpuIHNlc2FtZQ==".to_vec()] });
 bench_header!(bearer, Authorization<Bearer>, { vec![b"Bearer fpKL54jvWmEGVoRdCNjG".to_vec()] });
+
+#[cfg(feature = "compat")]
+impl<S> ::header::StandardHeader for Authorization<S>
+    where S: Scheme + Any + ::std::string::ToString
+{
+    #[inline]
+    fn http_header_name() -> ::http::header::HeaderName {
+        ::http::header::AUTHORIZATION
+    }
+}

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -219,3 +219,5 @@ mod tests {
 
 bench_header!(normal,
     CacheControl, { vec![b"no-cache, private".to_vec(), b"max-age=100".to_vec()] });
+
+standard_header!(CacheControl, CACHE_CONTROL);

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -144,3 +144,5 @@ mod tests {
             parse_option(b"upgrade".to_vec()));
     }
 }
+
+standard_header!(Connection, CONNECTION);

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -265,3 +265,5 @@ mod tests {
         assert_eq!("attachment; filename=\"colourful.csv\"".to_owned(), display_rendered);
     }
 }
+
+standard_header!(ContentDisposition, CONTENT_DISPOSITION);

--- a/src/header/common/content_encoding.rs
+++ b/src/header/common/content_encoding.rs
@@ -50,5 +50,13 @@ header! {
     }
 }
 
+#[cfg(feature = "compat")]
+impl ::header::StandardHeader for ContentEncoding {
+    #[inline]
+    fn http_header_name() -> http::header::HeaderName {
+        http::header::CONTENT_ENCODING
+    }
+}
+
 bench_header!(single, ContentEncoding, { vec![b"gzip".to_vec()] });
 bench_header!(multiple, ContentEncoding, { vec![b"gzip, deflate".to_vec()] });

--- a/src/header/common/content_encoding.rs
+++ b/src/header/common/content_encoding.rs
@@ -50,13 +50,7 @@ header! {
     }
 }
 
-#[cfg(feature = "compat")]
-impl ::header::StandardHeader for ContentEncoding {
-    #[inline]
-    fn http_header_name() -> http::header::HeaderName {
-        http::header::CONTENT_ENCODING
-    }
-}
+standard_header!(ContentEncoding, CONTENT_ENCODING);
 
 bench_header!(single, ContentEncoding, { vec![b"gzip".to_vec()] });
 bench_header!(multiple, ContentEncoding, { vec![b"gzip, deflate".to_vec()] });

--- a/src/header/common/content_language.rs
+++ b/src/header/common/content_language.rs
@@ -61,3 +61,5 @@ header! {
         test_header!(test2, vec![b"mi, en"]);
     }
 }
+
+standard_header!(ContentLanguage, CONTENT_LANGUAGE);

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -77,6 +77,7 @@ impl Header for ContentLength {
 
 #[cfg(feature = "compat")]
 impl ::header::StandardHeader for ContentLength {
+    #[inline]
     fn http_header_name() -> http::header::HeaderName {
         http::header::CONTENT_LENGTH
     }

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -75,13 +75,7 @@ impl Header for ContentLength {
     }
 }
 
-#[cfg(feature = "compat")]
-impl ::header::StandardHeader for ContentLength {
-    #[inline]
-    fn http_header_name() -> http::header::HeaderName {
-        http::header::CONTENT_LENGTH
-    }
-}
+standard_header!(ContentLength, CONTENT_LENGTH);
 
 impl fmt::Display for ContentLength {
     #[inline]

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -75,6 +75,13 @@ impl Header for ContentLength {
     }
 }
 
+#[cfg(feature = "compat")]
+impl ::header::StandardHeader for ContentLength {
+    fn http_header_name() -> http::header::HeaderName {
+        http::header::CONTENT_LENGTH
+    }
+}
+
 impl fmt::Display for ContentLength {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/header/common/content_location.rs
+++ b/src/header/common/content_location.rs
@@ -45,3 +45,5 @@ header! {
         test_header!(absolute, vec![b"http://www.example.org/hypertext/Overview.html"]);
     }
 }
+
+standard_header!(ContentLocation, CONTENT_LOCATION);

--- a/src/header/common/content_range.rs
+++ b/src/header/common/content_range.rs
@@ -188,3 +188,5 @@ impl Display for ContentRangeSpec {
         }
     }
 }
+
+standard_header!(ContentRange, CONTENT_RANGE);

--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -125,3 +125,5 @@ impl ContentType {
 impl Eq for ContentType {}
 
 bench_header!(bench, ContentType, { vec![b"application/json".to_vec()] });
+
+standard_header!(ContentType, CONTENT_TYPE);

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -292,3 +292,5 @@ mod tests {
 bench_header!(bench, Cookie, {
     vec![b"foo=bar; baz=quux".to_vec()]
 });
+
+standard_header!(Cookie, COOKIE);

--- a/src/header/common/date.rs
+++ b/src/header/common/date.rs
@@ -35,3 +35,5 @@ header! {
 bench_header!(imf_fixdate, Date, { vec![b"Sun, 07 Nov 1994 08:48:37 GMT".to_vec()] });
 bench_header!(rfc_850, Date, { vec![b"Sunday, 06-Nov-94 08:49:37 GMT".to_vec()] });
 bench_header!(asctime, Date, { vec![b"Sun Nov  6 08:49:37 1994".to_vec()] });
+
+standard_header!(Date, DATE);

--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -93,3 +93,5 @@ header! {
 }
 
 bench_header!(bench, ETag, { vec![b"W/\"nonemptytag\"".to_vec()] });
+
+standard_header!(ETag, ETAG);

--- a/src/header/common/expect.rs
+++ b/src/header/common/expect.rs
@@ -64,3 +64,5 @@ impl fmt::Display for Expect {
         f.write_str("100-continue")
     }
 }
+
+standard_header!(Expect, EXPECT);

--- a/src/header/common/expires.rs
+++ b/src/header/common/expires.rs
@@ -40,3 +40,5 @@ header! {
 bench_header!(imf_fixdate, Expires, { vec![b"Sun, 07 Nov 1994 08:48:37 GMT".to_vec()] });
 bench_header!(rfc_850, Expires, { vec![b"Sunday, 06-Nov-94 08:49:37 GMT".to_vec()] });
 bench_header!(asctime, Expires, { vec![b"Sun Nov  6 08:49:37 1994".to_vec()] });
+
+standard_header!(Expires, EXPIRES);

--- a/src/header/common/from.rs
+++ b/src/header/common/from.rs
@@ -27,3 +27,5 @@ header! {
         test_header!(test1, vec![b"webmaster@example.org"]);
     }
 }
+
+standard_header!(From, FROM);

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -135,3 +135,5 @@ mod tests {
 }
 
 bench_header!(bench, Host, { vec![b"foo.com:3000".to_vec()] });
+
+standard_header!(Host, HOST);

--- a/src/header/common/if_match.rs
+++ b/src/header/common/if_match.rs
@@ -71,3 +71,5 @@ bench_header!(star, IfMatch, { vec![b"*".to_vec()] });
 bench_header!(single , IfMatch, { vec![b"\"xyzzy\"".to_vec()] });
 bench_header!(multi, IfMatch,
               { vec![b"\"xyzzy\", \"r2d2xxxx\", \"c3piozzzz\"".to_vec()] });
+
+standard_header!(IfMatch, IF_MATCH);

--- a/src/header/common/if_modified_since.rs
+++ b/src/header/common/if_modified_since.rs
@@ -40,3 +40,5 @@ header! {
 bench_header!(imf_fixdate, IfModifiedSince, { vec![b"Sun, 07 Nov 1994 08:48:37 GMT".to_vec()] });
 bench_header!(rfc_850, IfModifiedSince, { vec![b"Sunday, 06-Nov-94 08:49:37 GMT".to_vec()] });
 bench_header!(asctime, IfModifiedSince, { vec![b"Sun Nov  6 08:49:37 1994".to_vec()] });
+
+standard_header!(IfModifiedSince, IF_MODIFIED_SINCE);

--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -87,3 +87,5 @@ mod tests {
 }
 
 bench_header!(bench, IfNoneMatch, { vec![b"W/\"nonemptytag\"".to_vec()] });
+
+standard_header!(IfNoneMatch, IF_NONE_MATCH);

--- a/src/header/common/if_range.rs
+++ b/src/header/common/if_range.rs
@@ -94,3 +94,5 @@ mod test_if_range {
     test_header!(test2, vec![b"\"xyzzy\""]);
     test_header!(test3, vec![b"this-is-invalid"], None::<IfRange>);
 }
+
+standard_header!(IfRange, IF_RANGE);

--- a/src/header/common/if_unmodified_since.rs
+++ b/src/header/common/if_unmodified_since.rs
@@ -41,3 +41,5 @@ header! {
 bench_header!(imf_fixdate, IfUnmodifiedSince, { vec![b"Sun, 07 Nov 1994 08:48:37 GMT".to_vec()] });
 bench_header!(rfc_850, IfUnmodifiedSince, { vec![b"Sunday, 06-Nov-94 08:49:37 GMT".to_vec()] });
 bench_header!(asctime, IfUnmodifiedSince, { vec![b"Sun Nov  6 08:49:37 1994".to_vec()] });
+
+standard_header!(IfUnmodifiedSince, IF_UNMODIFIED_SINCE);

--- a/src/header/common/last_modified.rs
+++ b/src/header/common/last_modified.rs
@@ -39,3 +39,5 @@ header! {
 bench_header!(imf_fixdate, LastModified, { vec![b"Sun, 07 Nov 1994 08:48:37 GMT".to_vec()] });
 bench_header!(rfc_850, LastModified, { vec![b"Sunday, 06-Nov-94 08:49:37 GMT".to_vec()] });
 bench_header!(asctime, LastModified, { vec![b"Sun Nov  6 08:49:37 1994".to_vec()] });
+
+standard_header!(LastModified, LAST_MODIFIED);

--- a/src/header/common/link.rs
+++ b/src/header/common/link.rs
@@ -1070,3 +1070,5 @@ mod tests {
 }
 
 bench_header!(bench_link, Link, { vec![b"<http://example.com/TheBook/chapter2>; rel=\"previous\"; rev=next; title=\"previous chapter\"; type=\"text/html\"; media=\"screen, tty\"".to_vec()] });
+
+standard_header!(Link, LINK);

--- a/src/header/common/location.rs
+++ b/src/header/common/location.rs
@@ -44,3 +44,5 @@ header! {
 }
 
 bench_header!(bench, Location, { vec![b"http://foo.com/hello:3000".to_vec()] });
+
+standard_header!(Location, LOCATION);

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -460,7 +460,7 @@ macro_rules! header {
 macro_rules! standard_header {
     ($local:ident, $hname:ident) => {
         #[cfg(feature = "compat")]
-        impl ::header::StandardHeader for $local {
+        impl $crate::header::StandardHeader for $local {
             #[inline]
             fn http_header_name() -> ::http::header::HeaderName {
                 ::http::header::$hname

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -455,6 +455,19 @@ macro_rules! header {
     };
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! standard_header {
+    ($local:ident, $hname:ident) => {
+        #[cfg(feature = "compat")]
+        impl ::header::StandardHeader for $local {
+            #[inline]
+            fn http_header_name() -> ::http::header::HeaderName {
+                ::http::header::$hname
+            }
+        }
+    }
+}
 
 mod accept_charset;
 mod accept_encoding;

--- a/src/header/common/origin.rs
+++ b/src/header/common/origin.rs
@@ -183,3 +183,5 @@ mod tests {
 }
 
 bench_header!(bench, Origin, { vec![b"https://foo.com".to_vec()] });
+
+standard_header!(Origin, ORIGIN);

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -92,3 +92,5 @@ fn test_parse_header() {
     let e: ::Result<Pragma> = Header::parse_header(&r);
     assert_eq!(e.ok(), None);
 }
+
+standard_header!(Pragma, PRAGMA);

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -199,3 +199,13 @@ mod benches {
     bench_header!(basic, ProxyAuthorization<Basic>, { vec![b"Basic QWxhZGRpbjpuIHNlc2FtZQ==".to_vec()] });
     bench_header!(bearer, ProxyAuthorization<Bearer>, { vec![b"Bearer fpKL54jvWmEGVoRdCNjG".to_vec()] });
 }
+
+#[cfg(feature = "compat")]
+impl<S> ::header::StandardHeader for ProxyAuthorization<S>
+    where S: Scheme + Any + ::std::string::ToString
+{
+    #[inline]
+    fn http_header_name() -> ::http::header::HeaderName {
+        ::http::header::AUTHORIZATION
+    }
+}

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -202,10 +202,10 @@ mod benches {
 
 #[cfg(feature = "compat")]
 impl<S> ::header::StandardHeader for ProxyAuthorization<S>
-    where S: Scheme + Any + ::std::string::ToString
+    where S: Scheme + Any + ::std::fmt::Display
 {
     #[inline]
     fn http_header_name() -> ::http::header::HeaderName {
-        ::http::header::AUTHORIZATION
+        ::http::header::PROXY_AUTHORIZATION
     }
 }

--- a/src/header/common/range.rs
+++ b/src/header/common/range.rs
@@ -412,3 +412,5 @@ mod tests {
 
 bench_header!(bytes_multi, Range, { vec![b"bytes=1-1001,2001-3001,10001-".to_vec()]});
 bench_header!(custom_unit, Range, { vec![b"other=0-100000".to_vec()]});
+
+standard_header!(Range, RANGE);

--- a/src/header/common/referer.rs
+++ b/src/header/common/referer.rs
@@ -43,3 +43,5 @@ header! {
 }
 
 bench_header!(bench, Referer, { vec![b"http://foo.com/hello:3000".to_vec()] });
+
+standard_header!(Referer, REFERER);

--- a/src/header/common/referrer_policy.rs
+++ b/src/header/common/referrer_policy.rs
@@ -131,3 +131,5 @@ mod tests {
         assert_eq!(a, b);
     }
 }
+
+standard_header!(ReferrerPolicy, REFERRER_POLICY);

--- a/src/header/common/retry_after.rs
+++ b/src/header/common/retry_after.rs
@@ -182,3 +182,5 @@ mod tests {
         assert_eq!(retry_after, RetryAfter::DateTime(expected));
     }
 }
+
+standard_header!(RetryAfter, RETRY_AFTER);

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -36,3 +36,5 @@ header! {
 }
 
 bench_header!(bench, Server, { vec![b"Some String".to_vec()] });
+
+standard_header!(Server, SERVER);

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -12,6 +12,9 @@ use std::str::from_utf8;
 /// "Set-Cookie" followed by a ":" and a cookie.  Each cookie begins with
 /// a name-value-pair, followed by zero or more attribute-value pairs.
 ///
+/// `SetCookie` _must not_ be encoded as a comma-delimited list. For this
+/// reason, it doesn't implement `fmt::Display` (and `std::string::ToString`).
+///
 /// # ABNF
 ///
 /// ```text
@@ -114,3 +117,5 @@ fn test_set_cookie_fmt() {
     ]));
     assert_eq!(headers.to_string(), "Set-Cookie: foo=bar\r\nSet-Cookie: baz=quux\r\n");
 }
+
+standard_header!(SetCookie, SET_COOKIE);

--- a/src/header/common/strict_transport_security.rs
+++ b/src/header/common/strict_transport_security.rs
@@ -210,3 +210,5 @@ mod tests {
 }
 
 bench_header!(bench, StrictTransportSecurity, { vec![b"max-age=15768000 ; includeSubDomains".to_vec()] });
+
+standard_header!(StrictTransportSecurity, STRICT_TRANSPORT_SECURITY);

--- a/src/header/common/te.rs
+++ b/src/header/common/te.rs
@@ -69,3 +69,5 @@ header! {
         test_header!(test3, vec![b""]);
     }
 }
+
+standard_header!(Te, TE);

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -68,3 +68,5 @@ impl TransferEncoding {
 
 bench_header!(normal, TransferEncoding, { vec![b"chunked, gzip".to_vec()] });
 bench_header!(ext, TransferEncoding, { vec![b"ext".to_vec()] });
+
+standard_header!(TransferEncoding, TRANSFER_ENCODING);

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -161,3 +161,5 @@ impl Display for Protocol {
 }
 
 bench_header!(bench, Upgrade, { vec![b"HTTP/2.0, RTA/x11, websocket".to_vec()] });
+
+standard_header!(Upgrade, UPGRADE);

--- a/src/header/common/user_agent.rs
+++ b/src/header/common/user_agent.rs
@@ -44,3 +44,5 @@ header! {
         test_header!(test2, vec![b"Bunnies"], Some(UserAgent::new("Bunnies")));
     }
 }
+
+standard_header!(UserAgent, USER_AGENT);

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -73,3 +73,5 @@ header! {
         }
     }
 }
+
+standard_header!(Vary, VARY);

--- a/src/header/common/warning.rs
+++ b/src/header/common/warning.rs
@@ -194,3 +194,5 @@ mod tests {
         }));
     }
 }
+
+standard_header!(Warning, WARNING);

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -295,7 +295,8 @@ mod tests {
         heads.set_raw("connection", b"Keep-Alive".as_ref());
         heads.set_raw("accept-ranges", b"bytes".as_ref());
         heads.set_raw("etag", b"\"1544639720\"".as_ref());
-        heads.set_raw("transfer-encoding", b"gzip, chunked".as_ref());
+        heads.set_raw("transfer-encoding", b"gzip".as_ref());
+        heads.append_raw("transfer-encoding", b"chunked".as_ref());
         heads.set_raw("content-length", b"7050".as_ref());
         heads.set_raw("content-type", b"text/css; charset=utf-8".as_ref());
         heads.set_raw("last-modified", b"Wed, 12 Dec 2018 18:35:20 GMT".as_ref());
@@ -327,7 +328,21 @@ mod tests {
         let headers2: Headers = hmap.clone().into();
         let hmap2: http::HeaderMap = headers.clone().into();
         assert_eq!(headers, headers2);
+        assert_eq!(headers2.len(), 3);
         assert_eq!(hmap, hmap2);
+        assert_eq!(hmap2.len(), 4);
+    }
+
+    #[test]
+    fn test_convert_sample() {
+        let headers = raw_headers_sample();
+        let hmap = http::HeaderMap::from(headers.clone());
+        let headers2 = Headers::from(hmap.clone());
+        let hmap2 = http::HeaderMap::from(headers2.clone());
+        assert_eq!(headers, headers2);
+        assert_eq!(headers2.len(), 14);
+        assert_eq!(hmap2, hmap);
+        assert_eq!(hmap2.len(), 15);
     }
 
     #[test]
@@ -335,7 +350,11 @@ mod tests {
         let headers = raw_headers_sample();
         let hmap = http::HeaderMap::from(&headers);
         let headers2 = Headers::from(&hmap);
+        let hmap2 = http::HeaderMap::from(&headers2);
         assert_eq!(headers, headers2);
+        assert_eq!(headers2.len(), 14);
+        assert_eq!(hmap2, hmap);
+        assert_eq!(hmap2.len(), 15);
     }
 
     #[test]
@@ -466,7 +485,7 @@ mod tests {
         let heads = raw_headers_sample();
         b.iter(|| {
             let hmap = http::HeaderMap::from(&heads);
-            assert_eq!(hmap.len(), 14);
+            assert_eq!(hmap.len(), 15);
         })
     }
 

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -131,8 +131,8 @@ impl From<Headers> for http::HeaderMap {
     }
 }
 
-impl From<&Headers> for http::HeaderMap {
-    fn from(headers: &Headers) -> http::HeaderMap {
+impl<'a> From<&'a Headers> for http::HeaderMap {
+    fn from(headers: &'a Headers) -> http::HeaderMap {
         let mut hmap = http::HeaderMap::new();
         for header in headers.iter() {
             let entry = hmap.entry(header.name())

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -7,8 +7,7 @@ use http;
 use http::header::{GetAll, HeaderMap, HeaderValue, ValueIter};
 
 use ::Result;
-use super::{Header, Headers};
-use super::raw::{Raw, RawLike};
+use super::{Header, Headers, Raw, RawLike};
 
 /// A trait for the "standard" headers that have an associated `HeaderName`
 /// constant in the _http_ crate.

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -499,4 +499,15 @@ mod tests {
             assert_eq!(heads.len(), 14);
         })
     }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_4_headers_from_map_by_value(b: &mut Bencher) {
+        let heads = raw_headers_sample();
+        let hmap: http::HeaderMap = heads.into();
+        b.iter(|| {
+            let heads = Headers::from(hmap.clone());
+            assert_eq!(heads.len(), 14);
+        })
+    }
 }

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -31,8 +31,8 @@ pub trait TypedHeaders {
     /// return `None` if not found.
     ///
     /// This variant will return `Option::None` if no header with the
-    /// associated key (`HeaderName`) is found in the map. If the map does
-    /// contain such a key, it will return the header type H or
+    /// associated key (`HeaderName`) is found in the collection. If the
+    /// collection does contain such a key, it will return the header type H or
     /// `Error::Header`.
     fn try_decode<H>(&self) -> Option<Result<H>>
         where H: StandardHeader;

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -13,9 +13,6 @@ pub trait TypedHeaders {
     fn decode<H>(&self) -> Result<H>
         where H: StandardHeader;
 
-    fn decode_any<H>(&self) -> Result<H>
-        where H: Header;
-
     fn encode<H>(&mut self, val: &H)
         where H: StandardHeader;
 
@@ -28,14 +25,6 @@ impl TypedHeaders for HeaderMap {
         where H: StandardHeader
     {
         let vals = self.get_all(H::http_header_name());
-        H::parse_header(&vals)
-    }
-
-    fn decode_any<H>(&self) -> Result<H>
-        where H: Header
-    {
-        let vals = self.get_all(H::header_name());
-        // FIXME: Perf: AsHeaderName for &str validates and down cases
         H::parse_header(&vals)
     }
 

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -125,14 +125,21 @@ impl<'a> From<&'a http::HeaderMap> for Headers {
 }
 
 impl From<Headers> for http::HeaderMap {
+    #[inline]
     fn from(headers: Headers) -> http::HeaderMap {
-        let mut header_map = http::HeaderMap::new();
+        http::HeaderMap::from(&headers)
+    }
+}
+
+impl From<&Headers> for http::HeaderMap {
+    fn from(headers: &Headers) -> http::HeaderMap {
+        let mut hmap = http::HeaderMap::new();
         for header in headers.iter() {
-            let entry = header_map.entry(header.name())
-                .expect("attempted to convert invalid header name");
+            let entry = hmap.entry(header.name())
+                .expect("convert invalid header name");
             let mut value_iter = header.raw().iter().map(|line| {
                 http::header::HeaderValue::from_bytes(line)
-                    .expect("attempted to convert invalid header value")
+                    .expect("convert invalid header value")
             });
             match entry {
                 http::header::Entry::Occupied(mut  occupied) => {
@@ -150,7 +157,7 @@ impl From<Headers> for http::HeaderMap {
                 }
             }
         }
-        header_map
+        hmap
     }
 }
 

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -295,7 +295,7 @@ mod tests {
         heads.set_raw("connection", b"Keep-Alive".as_ref());
         heads.set_raw("accept-ranges", b"bytes".as_ref());
         heads.set_raw("etag", b"\"1544639720\"".as_ref());
-        heads.set_raw("content-encoding", b"gzip".as_ref());
+        heads.set_raw("transfer-encoding", b"gzip, chunked".as_ref());
         heads.set_raw("content-length", b"7050".as_ref());
         heads.set_raw("content-type", b"text/css; charset=utf-8".as_ref());
         heads.set_raw("last-modified", b"Wed, 12 Dec 2018 18:35:20 GMT".as_ref());

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -1,6 +1,6 @@
 //! Implementation module for various _compat_ features with the _http_ crate.
 
-use std::string::ToString;
+use std::fmt::Display;
 
 use http::header::HeaderMap;
 
@@ -39,17 +39,19 @@ pub trait TypedHeaders {
 
     /// Encode and write the specified typed header value in the collection.
     ///
-    /// This will overwrite any preexisting values with the same
+    /// Uses the `Display` format of the provided header value to write a single
+    /// header. This will overwrite any preexisting values with the same
     /// key (`HeaderName`). Use `encode_append` instead to avoid this.
-    fn encode<H>(&mut self, val: &H)
-        where H: StandardHeader + ToString;
+    fn encode<H>(&mut self, value: &H)
+        where H: StandardHeader + Display;
 
     /// Encode and append the specified typed header value into the collection.
     ///
-    /// If the collection previously had a value for the same key, the
-    /// additional value is appended to the end.
-    fn encode_append<H>(&mut self, val: &H)
-        where H: StandardHeader + ToString;
+    /// Uses the `Display` format of the provided header value to append a
+    /// single header. If the collection previously had a value for the same
+    /// key, the additional value is appended to the end.
+    fn encode_append<H>(&mut self, value: &H)
+        where H: StandardHeader + Display;
 }
 
 impl TypedHeaders for HeaderMap {
@@ -73,7 +75,7 @@ impl TypedHeaders for HeaderMap {
     }
 
     fn encode<H>(&mut self, val: &H)
-        where H: StandardHeader + ToString
+        where H: StandardHeader + Display
     {
         self.insert(
             H::http_header_name(),
@@ -81,7 +83,7 @@ impl TypedHeaders for HeaderMap {
     }
 
     fn encode_append<H>(&mut self, val: &H)
-        where H: StandardHeader + ToString
+        where H: StandardHeader + Display
     {
         self.append(
             H::http_header_name(),

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -1,14 +1,17 @@
 //! Implementation module for various _compat_ features with the _http_ crate.
 
+use std::convert::From;
 use std::fmt::Display;
 
-use http::header::HeaderMap;
+use http;
+use http::header::{GetAll, HeaderMap, HeaderValue, ValueIter};
 
 use ::Result;
-use super::Header;
+use super::{Header, Headers};
+use super::raw::{Raw, RawLike};
 
 /// A trait for the "standard" headers that have an associated `HeaderName`
-/// constant in the `http` crate.
+/// constant in the _http_ crate.
 pub trait StandardHeader: Header + Sized {
     /// The `HeaderName` from the _http_ crate for this header.
     fn http_header_name() -> ::http::header::HeaderName;
@@ -54,6 +57,10 @@ pub trait TypedHeaders {
         where H: StandardHeader + Display;
 }
 
+/// Iterator adaptor for HeaderValue
+#[derive(Debug)]
+pub struct ValueMapIter<'a>(ValueIter<'a, HeaderValue>);
+
 impl TypedHeaders for HeaderMap {
     fn decode<H>(&self) -> Result<H>
         where H: StandardHeader
@@ -91,14 +98,114 @@ impl TypedHeaders for HeaderMap {
     }
 }
 
+impl From<http::HeaderMap> for Headers {
+    fn from(mut header_map: http::HeaderMap) -> Headers {
+        let mut headers = Headers::new();
+        for (name, mut value_drain) in header_map.drain() {
+            if let Some(first_value) = value_drain.next() {
+                let mut raw: Raw = first_value.as_bytes().into();
+                for value in value_drain {
+                    raw.push(value.as_bytes());
+                }
+                headers.append_raw(name.as_str().to_string(), raw);
+            }
+        }
+        headers
+    }
+}
+
+impl<'a> From<&'a http::HeaderMap> for Headers {
+    fn from(header_map: &'a http::HeaderMap) -> Headers {
+        let mut headers = Headers::new();
+        for (name, value) in header_map.iter() {
+            headers.append_raw_str(name.as_str(), value.as_bytes());
+        }
+        headers
+    }
+}
+
+impl From<Headers> for http::HeaderMap {
+    fn from(headers: Headers) -> http::HeaderMap {
+        let mut header_map = http::HeaderMap::new();
+        for header in headers.iter() {
+            let entry = header_map.entry(header.name())
+                .expect("attempted to convert invalid header name");
+            let mut value_iter = header.raw().iter().map(|line| {
+                http::header::HeaderValue::from_bytes(line)
+                    .expect("attempted to convert invalid header value")
+            });
+            match entry {
+                http::header::Entry::Occupied(mut  occupied) => {
+                    for value in value_iter {
+                        occupied.append(value);
+                    }
+                },
+                http::header::Entry::Vacant(vacant) => {
+                    if let Some(first_value) = value_iter.next() {
+                        let mut occupied = vacant.insert_entry(first_value);
+                        for value in value_iter {
+                            occupied.append(value);
+                        }
+                    }
+                }
+            }
+        }
+        header_map
+    }
+}
+
+impl<'a> Iterator for ValueMapIter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(HeaderValue::as_bytes)
+    }
+}
+
+impl<'a> RawLike<'a> for GetAll<'a, HeaderValue> {
+    type IntoIter = ValueMapIter<'a>;
+
+    fn len(&'a self) -> usize {
+        self.iter().count()
+    }
+
+    fn one(&'a self) -> Option<&'a [u8]> {
+        let mut iter = self.iter();
+        if let Some(v) = iter.next() {
+            if iter.next().is_none() {
+                return Some(v.as_bytes());
+            }
+        }
+        None
+    }
+
+    fn iter(&'a self) -> ValueMapIter<'a> {
+        ValueMapIter(self.iter())
+    }
+}
+
+impl<'a> RawLike<'a> for &'a HeaderValue {
+    type IntoIter = ::std::iter::Once<&'a [u8]>;
+
+    fn len(&'a self) -> usize {
+        1
+    }
+
+    fn one(&'a self) -> Option<&'a [u8]> {
+        Some(self.as_bytes())
+    }
+
+    fn iter(&'a self) -> Self::IntoIter {
+        ::std::iter::once(self.as_bytes())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use http;
-    use super::TypedHeaders;
-    use ::header::{ContentEncoding, ContentLength, Encoding, Te, ETag};
-
-    #[cfg(feature = "nightly")]
-    use ::header::Header;
+    use ::header::{
+        ContentEncoding, ContentLength, Encoding, ETag, Host, Te,
+        Header, Headers, TypedHeaders};
 
     #[cfg(feature = "nightly")]
     use test::Bencher;
@@ -174,9 +281,105 @@ mod tests {
             vec![Encoding::Identity, Encoding::Gzip, Encoding::Chunked]);
     }
 
+    #[test]
+    fn test_compat_convert() {
+        use http;
+
+        let mut orig_hyper_headers = Headers::new();
+        orig_hyper_headers.set(ContentLength(11));
+        orig_hyper_headers.set(Host::new("foo.bar", None));
+        orig_hyper_headers.append_raw("x-foo", b"bar".to_vec());
+        orig_hyper_headers.append_raw("x-foo", b"quux".to_vec());
+
+        let mut orig_http_headers = http::HeaderMap::new();
+        orig_http_headers.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
+        orig_http_headers.insert(http::header::HOST, "foo.bar".parse().unwrap());
+        orig_http_headers.append("x-foo", "bar".parse().unwrap());
+        orig_http_headers.append("x-foo", "quux".parse().unwrap());
+
+        let conv_hyper_headers: Headers = orig_http_headers.clone().into();
+        let conv_http_headers: http::HeaderMap = orig_hyper_headers.clone().into();
+        assert_eq!(orig_hyper_headers, conv_hyper_headers);
+        assert_eq!(orig_http_headers, conv_http_headers);
+
+        // Test Headers::from(&http::HeaderMap)
+        let conv_hyper_headers: Headers = Headers::from(&orig_http_headers);
+        assert_eq!(orig_hyper_headers, conv_hyper_headers);
+    }
+
+    #[test]
+    fn test_compat_value_parse() {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+        let ce = ContentEncoding::parse_header(&val).unwrap();
+        assert_eq!(ce, ContentEncoding(vec![Encoding::Chunked, Encoding::Gzip]))
+    }
+
+    #[test]
+    fn test_compat_multi_value_parse() {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        hheads.append(http::header::CONTENT_ENCODING,
+                      "br".parse().unwrap());
+
+        let vals = hheads.get_all(http::header::CONTENT_ENCODING);
+        let ce = ContentEncoding::parse_header(&vals).unwrap();
+        assert_eq!(
+            ce,
+            ContentEncoding(vec![
+                Encoding::Chunked, Encoding::Gzip, Encoding::Brotli
+            ])
+        )
+    }
+
     #[cfg(feature = "nightly")]
     #[bench]
-    fn bench_0_get_parse_int(b: &mut Bencher) {
+    fn bench_0_value_parse(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            ContentEncoding::parse_header(&val).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_0_value_parse_extra_str(b: &mut Bencher) {
+        use http;
+        use header::Raw;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_ENCODING,
+                      "chunked, gzip".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_ENCODING).unwrap();
+            let r: Raw = val.to_str().unwrap().into();
+            ContentEncoding::parse_header(&r).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_0_value_parse_int(b: &mut Bencher) {
+        use http;
+        let mut hheads = http::HeaderMap::new();
+        hheads.insert(http::header::CONTENT_LENGTH, "1024".parse().unwrap());
+        b.iter(|| {
+            let val = hheads.get(http::header::CONTENT_LENGTH).unwrap();
+            ContentLength::parse_header(&val).unwrap();
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_1_get_parse_int(b: &mut Bencher) {
         let mut hmap = http::HeaderMap::new();
         hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
         b.iter(|| {
@@ -188,7 +391,7 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[bench]
-    fn bench_0_get_parse_int_one(b: &mut Bencher) {
+    fn bench_1_get_parse_int_one(b: &mut Bencher) {
         let mut hmap = http::HeaderMap::new();
         hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
         b.iter(|| {
@@ -200,7 +403,7 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[bench]
-    fn bench_1_decode_int(b: &mut Bencher) {
+    fn bench_2_decode_int(b: &mut Bencher) {
         let mut hmap = http::HeaderMap::new();
         hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
         b.iter(|| {
@@ -211,7 +414,7 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[bench]
-    fn bench_1_try_decode_int(b: &mut Bencher) {
+    fn bench_2_try_decode_int(b: &mut Bencher) {
         let mut hmap = http::HeaderMap::new();
         hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
         b.iter(|| {
@@ -222,7 +425,7 @@ mod tests {
 
     #[cfg(feature = "nightly")]
     #[bench]
-    fn bench_2_get_orig_int(b: &mut Bencher) {
+    fn bench_3_get_orig_int(b: &mut Bencher) {
         let mut hdrs = ::header::Headers::new();
         hdrs.set_raw("content-length", "11");
         b.iter(|| {

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -4,13 +4,12 @@ use ::Result;
 use super::Header;
 
 /// A trait for standard headers with constant names.
-pub trait StandardHeader: Header + Sized + ToString {
+pub trait StandardHeader: Header + Sized {
     /// The http crate HeaderName
-    fn http_header_name() -> http::header::HeaderName;
+    fn http_header_name() -> ::http::header::HeaderName;
 }
 
 pub trait TypedHeaders {
-
     fn decode<H>(&self) -> Result<H>
         where H: StandardHeader;
 
@@ -18,10 +17,10 @@ pub trait TypedHeaders {
         where H: StandardHeader;
 
     fn encode<H>(&mut self, val: &H)
-        where H: StandardHeader;
+        where H: StandardHeader + ToString;
 
     fn encode_append<H>(&mut self, val: &H)
-        where H: StandardHeader;
+        where H: StandardHeader + ToString;
 }
 
 impl TypedHeaders for HeaderMap {
@@ -45,7 +44,7 @@ impl TypedHeaders for HeaderMap {
     }
 
     fn encode<H>(&mut self, val: &H)
-        where H: StandardHeader
+        where H: StandardHeader + ToString
     {
         self.insert(
             H::http_header_name(),
@@ -53,7 +52,7 @@ impl TypedHeaders for HeaderMap {
     }
 
     fn encode_append<H>(&mut self, val: &H)
-        where H: StandardHeader
+        where H: StandardHeader + ToString
     {
         self.append(
             H::http_header_name(),

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -1,0 +1,111 @@
+use std::string::ToString;
+use http::header::HeaderMap;
+use ::Result;
+use super::Header;
+
+/// A trait for standard headers with constant names.
+pub trait StandardHeader: Header + Sized + ToString {
+    /// The http crate HeaderName
+    fn http_header_name() -> http::header::HeaderName;
+}
+
+pub trait TypedHeaders {
+    fn decode<H>(&self) -> Result<H>
+        where H: StandardHeader;
+
+    fn decode_any<H>(&self) -> Result<H>
+        where H: Header;
+}
+
+impl TypedHeaders for HeaderMap {
+    fn decode<H>(&self) -> Result<H>
+        where H: StandardHeader
+    {
+        let vals = self.get_all(H::http_header_name());
+        H::parse_header(&vals)
+    }
+
+    fn decode_any<H>(&self) -> Result<H>
+        where H: Header
+    {
+        let vals = self.get_all(H::header_name());
+        // FIXME: Performance: AsHeaderName for &str validates and down cases
+        // the name.
+        H::parse_header(&vals)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http;
+    use super::TypedHeaders;
+    use ::header::ContentLength;
+
+    #[cfg(feature = "nightly")]
+    use ::header::Header;
+
+    #[cfg(feature = "nightly")]
+    use test::Bencher;
+
+    #[test]
+    fn test_empty_decode() {
+        let hmap = http::HeaderMap::new();
+        let len = hmap.decode::<ContentLength>();
+        assert!(len.is_err());
+        println!("{:?}", len);
+    }
+
+    #[test]
+    fn test_decode() {
+        let mut hmap = http::HeaderMap::new();
+        hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
+        let len: ContentLength = hmap.decode().unwrap();
+        assert_eq!(*len, 11);
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_0_get_parse_int(b: &mut Bencher) {
+        let mut hmap = http::HeaderMap::new();
+        hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
+        b.iter(|| {
+            let vals = hmap.get_all(http::header::CONTENT_LENGTH);
+            let len = ContentLength::parse_header(&vals).unwrap();
+            assert_eq!(*len, 11);
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_0_get_parse_int_one(b: &mut Bencher) {
+        let mut hmap = http::HeaderMap::new();
+        hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
+        b.iter(|| {
+            let val = hmap.get(http::header::CONTENT_LENGTH).unwrap();
+            let len = ContentLength::parse_header(&val).unwrap();
+            assert_eq!(*len, 11);
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_1_decode_int(b: &mut Bencher) {
+        let mut hmap = http::HeaderMap::new();
+        hmap.insert(http::header::CONTENT_LENGTH, "11".parse().unwrap());
+        b.iter(|| {
+            let len: ContentLength = hmap.decode().unwrap();
+            assert_eq!(*len, 11);
+        })
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_2_get_orig_int(b: &mut Bencher) {
+        let mut hdrs = ::header::Headers::new();
+        hdrs.set_raw("content-length", "11");
+        b.iter(|| {
+            let len: &ContentLength = hdrs.get().unwrap();
+            assert_eq!(**len, 11);
+        })
+    }
+}

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -160,7 +160,7 @@ pub mod parsing;
 mod compat;
 
 #[cfg(feature = "compat")]
-pub use self::compat::StandardHeader;
+pub use self::compat::{TypedHeaders, StandardHeader};
 
 /// A trait for any object that will represent a header field and value.
 ///

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -88,7 +88,7 @@
 //!     *ce,
 //!     vec![Encoding::Identity, Encoding::Gzip, Encoding::Chunked]
 //! );
-//! Ok(())
+//! # Ok(())
 //! # }
 //! # #[cfg(feature = "compat")]
 //! # fn main() {

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -156,6 +156,11 @@ mod raw;
 mod shared;
 pub mod parsing;
 
+#[cfg(feature = "compat")]
+mod compat;
+
+#[cfg(feature = "compat")]
+pub use self::compat::StandardHeader;
 
 /// A trait for any object that will represent a header field and value.
 ///

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -62,6 +62,43 @@
 //! # }
 //! ```
 //!
+//! ## `TypedHeaders` extension to `http::HeaderMap`
+//!
+//! The [`TypedHeaders`](trait.TypedHeaders.html) extension trait provides more
+//! convenient `encode`/`decode` methods on `HeaderMap` generically for the
+//! standard header types named in the _http_ crate:
+//!
+//! ```
+//! # #[cfg(feature = "compat")]
+//! # extern crate hyperx;
+//! # #[cfg(feature = "compat")]
+//! # extern crate http;
+//! # #[cfg(feature = "compat")]
+//! # fn run() -> Result<(), Box<std::error::Error>> {
+//! use http::header::HeaderMap;
+//! use hyperx::header::{ContentEncoding, Encoding, TypedHeaders};
+//!
+//! let mut hmap = http::HeaderMap::new();
+//! hmap.encode(
+//!     &ContentEncoding(vec![Encoding::Identity]));
+//! hmap.encode_append(
+//!     &ContentEncoding(vec![Encoding::Gzip, Encoding::Chunked]));
+//! let ce: ContentEncoding = hmap.decode()?;
+//! assert_eq!(
+//!     *ce,
+//!     vec![Encoding::Identity, Encoding::Gzip, Encoding::Chunked]
+//! );
+//! Ok(())
+//! # }
+//! # #[cfg(feature = "compat")]
+//! # fn main() {
+//! #     run().unwrap();
+//! # }
+//! # #[cfg(not(feature = "compat"))]
+//! # fn main() {
+//! # }
+//! ```
+//!
 //! ## Defining Custom Headers
 //!
 //! Hyper*x* provides many of the most commonly used headers in HTTP. If you

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -2,9 +2,6 @@ use std::borrow::Cow;
 use std::fmt;
 use bytes::Bytes;
 
-#[cfg(feature = "compat")]
-use http::header::{GetAll, HeaderValue, ValueIter};
-
 /// Trait for raw bytes parsing access to header values (aka lines) for a single
 /// header name.
 pub trait RawLike<'a> {
@@ -209,60 +206,6 @@ impl From<Bytes> for Raw {
     #[inline]
     fn from(val: Bytes) -> Raw {
         Raw(Lines::One(val))
-    }
-}
-
-/// Iterator adaptor for HeaderValue
-#[cfg(feature = "compat")]
-#[derive(Debug)]
-pub struct ValueMapIter<'a>(ValueIter<'a, HeaderValue>);
-
-#[cfg(feature = "compat")]
-impl<'a> Iterator for ValueMapIter<'a> {
-    type Item = &'a [u8];
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(HeaderValue::as_bytes)
-    }
-}
-
-#[cfg(feature = "compat")]
-impl<'a> RawLike<'a> for GetAll<'a, HeaderValue> {
-    type IntoIter = ValueMapIter<'a>;
-
-    fn len(&'a self) -> usize {
-        self.iter().count()
-    }
-
-    fn one(&'a self) -> Option<&'a [u8]> {
-        let mut iter = self.iter();
-        if let Some(v) = iter.next() {
-            if iter.next().is_none() {
-                return Some(v.as_bytes());
-            }
-        }
-        None
-    }
-
-    fn iter(&'a self) -> ValueMapIter<'a> {
-        ValueMapIter(self.iter())
-    }
-}
-
-#[cfg(feature = "compat")]
-impl<'a> RawLike<'a> for &'a HeaderValue {
-    type IntoIter = ::std::iter::Once<&'a [u8]>;
-
-    fn len(&'a self) -> usize {
-        1
-    }
-
-    fn one(&'a self) -> Option<&'a [u8]> {
-        Some(self.as_bytes())
-    }
-
-    fn iter(&'a self) -> Self::IntoIter {
-        ::std::iter::once(self.as_bytes())
     }
 }
 


### PR DESCRIPTION
This adds a `TypedHeaders` extension trait providing more convenient encode/decode methods on `HeaderMap` for _hyperx_ typed headers, implemented using a new `StandardHeader` trait and `standard_header!` macro, with associate function for the `HeaderName` constant of  the _http_ crate.   This is implemented in a new  _compat_  module, and prior _compat_ feature code is further consolidated to header/compat.rs.  Otherwise the feature is strictly additive and should be backward-compatible.

This is the next step of compatibility integration as concluded in #1.  Available usage summary (from included rustdoc-test):

``` rust
use http::header::HeaderMap;
use hyperx::header::{ContentEncoding, Encoding, TypedHeaders};

let mut hmap = http::HeaderMap::new();
hmap.encode(
    &ContentEncoding(vec![Encoding::Identity]));
hmap.encode_append(
    &ContentEncoding(vec![Encoding::Gzip, Encoding::Chunked]));
let ce: ContentEncoding = hmap.decode()?;

assert_eq!(
    *ce,
    vec![Encoding::Identity, Encoding::Gzip, Encoding::Chunked]
);
```