### PR TITLE
build.rs: fix with rustc not built from Git

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -33,17 +33,17 @@ fn rustc_version() -> Vec<u16> {
     let out = String::from_utf8(out.stdout).unwrap();
     for l in out.lines() {
         if l.starts_with("rustc ") {
-            let v = &l[6..];
+            let mut v = &l[6..];
             if let Some(e) = v.find(" ") {
-                let v = &v[..e];
-                let mut vp = v.split("-");
-                if let Some(v) = vp.next() {
-                    let vs: Vec<u16> = v.split(".")
-                        .filter_map(|vss| vss.parse().ok())
-                        .collect();
-                    if !vs.is_empty() {
-                        return vs;
-                    }
+                v = &v[..e];
+            }
+            let mut vp = v.split("-");
+            if let Some(v) = vp.next() {
+                let vs: Vec<u16> = v.split(".")
+                    .filter_map(|vss| vss.parse().ok())
+                    .collect();
+                if !vs.is_empty() {
+                    return vs;
                 }
             }
         }


### PR DESCRIPTION
I couldn't build hyperx because my rustc (from Nixpkgs) has a version output looks like this:

    rustc 1.34.2

There's no Git information in parentheses after the version. I assume that this is because it was not built from a Git checkout.

To fix this, I made it so that if no space occurs after the "rustc " prefix, the whole remaining string is used as the version.

