### PR TITLE
upgrade to percent-encoding 2.1.x \w api changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -100,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -169,7 +169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ httparse = "1.0"
 language-tags = "0.2"
 log = "0.4"
 mime = "0.3.2"
-percent-encoding = "1.0"
+percent-encoding = ">=2.1.0, <2.2"
 time = ">=0.1.37, <0.2"
 unicase = "2.0"
 

--- a/src/header/parsing.rs
+++ b/src/header/parsing.rs
@@ -142,7 +142,10 @@ pub fn parse_extended_value(val: &str) -> ::Result<ExtendedValue> {
 impl Display for ExtendedValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let encoded_value =
-            percent_encoding::percent_encode(&self.value[..], self::percent_encoding_http::HTTP_VALUE);
+            percent_encoding::percent_encode(
+                &self.value[..],
+                self::percent_encoding_http::HTTP_VALUE
+            );
         if let Some(ref lang) = self.language_tag {
             write!(f, "{}'{}'{}", self.charset, lang, encoded_value)
         } else {
@@ -156,23 +159,23 @@ impl Display for ExtendedValue {
 ///
 /// [url]: https://tools.ietf.org/html/rfc5987#section-3.2
 pub fn http_percent_encode(f: &mut fmt::Formatter, bytes: &[u8]) -> fmt::Result {
-    let encoded = percent_encoding::percent_encode(bytes, self::percent_encoding_http::HTTP_VALUE);
+    let encoded = percent_encoding::percent_encode(
+        bytes,
+        self::percent_encoding_http::HTTP_VALUE
+    );
     fmt::Display::fmt(&encoded, f)
 }
 
 mod percent_encoding_http {
-    use percent_encoding;
+    use percent_encoding::{AsciiSet, CONTROLS};
 
-    // internal module because macro is hard-coded to make a public item
-    // but we don't want to public export this item
-    define_encode_set! {
-        // This encode set is used for HTTP header values and is defined at
-        // https://tools.ietf.org/html/rfc5987#section-3.2
-        pub HTTP_VALUE = [percent_encoding::SIMPLE_ENCODE_SET] | {
-            ' ', '"', '%', '\'', '(', ')', '*', ',', '/', ':', ';', '<', '-', '>', '?',
-            '[', '\\', ']', '{', '}'
-        }
-    }
+    // This encode set is used for HTTP header values and is defined at
+    // https://tools.ietf.org/html/rfc5987#section-3.2
+    pub const HTTP_VALUE: &AsciiSet = &CONTROLS
+        .add(b' ') .add(b'"') .add(b'%') .add(b'\'') .add(b'(')  .add(b')')
+        .add(b'*') .add(b',') .add(b'/') .add(b':')  .add(b';')  .add(b'<')
+        .add(b'-') .add(b'>') .add(b'?') .add(b'[')  .add(b'\\') .add(b']')
+        .add(b'{') .add(b'}');
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ extern crate httparse;
 extern crate language_tags;
 #[macro_use] extern crate log;
 pub extern crate mime;
-#[macro_use] extern crate percent_encoding;
+extern crate percent_encoding;
 extern crate time;
 extern crate unicase;
 


### PR DESCRIPTION
Note that the percent-encoding 2.1.0 crate has MSRV 1.33.0, as per our current CI failure with this upgrade.  Holding this one for inclusion in an 0.16 or higher release, possibly pending other changes.  

Feel free to comment if you need this upgrade sooner. 