### PR TITLE
Headers struct behind non-default headers feature gate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
   - 'if [ "$WITH_LOCK" != "true" ]; then cargo update; fi'
   - 'cargo test'
   - 'cargo test --features headers'
-  - 'if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test --features nightly; fi'
+  - 'if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test --all-features; fi'
 # See https://levans.fr/rust_travis_cache.html
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: rust
 dist: xenial
 script:
   - 'if [ "$WITH_LOCK" != "true" ]; then cargo update; fi'
-  - 'cargo test --no-default-features'
   - 'cargo test'
+  - 'cargo test --features headers'
   - 'if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then cargo test --features nightly; fi'
 # See https://levans.fr/rust_travis_cache.html
 cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
   anyone would be using recent versions without this feature. The feature gate
   name is retained for now, but has no effect.
 
+* Place the legacy `Headers` struct under a new non-default _headers_ feature
+  gate. Note that use of this type is no longer required nor recommended for
+  parsing and serialization of typed headers. See the rewritten typed header
+  doc examples.  Consider replacing with the _http_ crate `HeaderMap` and the
+  `TypedHeaders` extension trait introduced here in 0.15.0.
+
 * Upgrade (unconstrain) _cfg-if_ dependency to (0.1.10 is MSRV 1.31.0)
 
 * Upgrade _unicase_ to (min) 2.1.0 to avoid compile failures with older

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.16.0 (TBD)
 
+* The default _compat_ feature is no longer optional, as its unlikely that
+  anyone would be using recent versions without this feature. The feature gate
+  name is retained for now, but has no effect.
+
 * Upgrade (unconstrain) _cfg-if_ dependency to (0.1.10 is MSRV 1.31.0)
 
 * Upgrade _unicase_ to (min) 2.1.0 to avoid compile failures with older

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,6 @@ nightly = []
 raw_status = []
 compat = [] # no-op for backward compatibility
 headers = []
+
+[package.metadata.docs.rs]
+features = ["headers"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ unicase             = { version=">=2.1.0, <2.6" }
 nightly = []
 raw_status = []
 compat = [] # no-op for backward compatibility
+headers = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ build = "build.rs"
 [dependencies]
 base64              = { version=">=0.10.1, <0.11" }
 bytes               = { version=">=0.4.4, <0.5" }
-http                = { version=">=0.1, <0.2", optional=true }
+http                = { version=">=0.1, <0.2" }
 httparse            = { version=">=1.0, <1.4" }
 language-tags       = { version=">=0.2, <0.3" }
 log                 = { version=">=0.4, <0.5" }
@@ -34,7 +34,6 @@ time                = { version=">=0.1.37, <0.2" }
 unicase             = { version=">=2.1.0, <2.6" }
 
 [features]
-default = [ "compat" ]
 nightly = []
 raw_status = []
-compat = [ "http" ]
+compat = [] # no-op for backward compatibility

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,8 @@ install:
 build: false
 
 test_script:
-  - cargo test --no-default-features
   - cargo test
+  - cargo test --features headers
   - cargo update
   - cargo test
+  - cargo test --features headers

--- a/src/header/common/accept.rs
+++ b/src/header/common/accept.rs
@@ -30,37 +30,41 @@ header! {
     ///
     /// # Examples
     /// ```
-    /// use hyperx::header::{Headers, Accept, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{Accept, qitem, TypedHeaders};
     /// use hyperx::mime;
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     ///
-    /// headers.set(
-    ///     Accept(vec![
+    /// headers.encode(
+    ///     &Accept(vec![
     ///         qitem(mime::TEXT_HTML),
     ///     ])
     /// );
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Accept, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{Accept, qitem, TypedHeaders};
     /// use hyperx::mime;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Accept(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Accept(vec![
     ///         qitem(mime::APPLICATION_JSON),
     ///     ])
     /// );
     /// ```
+    ///
     /// ```
-    /// use hyperx::header::{Headers, Accept, QualityItem, q, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{Accept, QualityItem, q, qitem, TypedHeaders};
     /// use hyperx::mime;
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     ///
-    /// headers.set(
-    ///     Accept(vec![
+    /// headers.encode(
+    ///     &Accept(vec![
     ///         qitem(mime::TEXT_HTML),
     ///         qitem("application/xhtml+xml".parse().unwrap()),
     ///         QualityItem::new(

--- a/src/header/common/accept_charset.rs
+++ b/src/header/common/accept_charset.rs
@@ -22,30 +22,33 @@ header! {
     ///
     /// # Examples
     /// ```
-    /// use hyperx::header::{Headers, AcceptCharset, Charset, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptCharset, Charset, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptCharset(vec![qitem(Charset::Us_Ascii)])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptCharset(vec![qitem(Charset::Us_Ascii)])
     /// );
     /// ```
     /// ```
-    /// use hyperx::header::{Headers, AcceptCharset, Charset, q, QualityItem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptCharset, Charset, q, QualityItem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptCharset(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptCharset(vec![
     ///         QualityItem::new(Charset::Us_Ascii, q(900)),
     ///         QualityItem::new(Charset::Iso_8859_10, q(200)),
     ///     ])
     /// );
     /// ```
     /// ```
-    /// use hyperx::header::{Headers, AcceptCharset, Charset, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptCharset, Charset, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptCharset(vec![qitem(Charset::Ext("utf-8".to_owned()))])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptCharset(vec![qitem(Charset::Ext("utf-8".to_owned()))])
     /// );
     /// ```
     (AcceptCharset, "Accept-Charset") => (QualityItem<Charset>)+

--- a/src/header/common/accept_encoding.rs
+++ b/src/header/common/accept_encoding.rs
@@ -26,19 +26,21 @@ header! {
     ///
     /// # Examples
     /// ```
-    /// use hyperx::header::{Headers, AcceptEncoding, Encoding, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptEncoding, Encoding, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptEncoding(vec![qitem(Encoding::Chunked)])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptEncoding(vec![qitem(Encoding::Chunked)])
     /// );
     /// ```
     /// ```
-    /// use hyperx::header::{Headers, AcceptEncoding, Encoding, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptEncoding, Encoding, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptEncoding(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptEncoding(vec![
     ///         qitem(Encoding::Chunked),
     ///         qitem(Encoding::Gzip),
     ///         qitem(Encoding::Deflate),
@@ -46,11 +48,12 @@ header! {
     /// );
     /// ```
     /// ```
-    /// use hyperx::header::{Headers, AcceptEncoding, Encoding, QualityItem, q, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptEncoding, Encoding, QualityItem, q, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptEncoding(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptEncoding(vec![
     ///         qitem(Encoding::Chunked),
     ///         QualityItem::new(Encoding::Gzip, q(600)),
     ///         QualityItem::new(Encoding::EncodingExt("*".to_owned()), q(0)),

--- a/src/header/common/accept_language.rs
+++ b/src/header/common/accept_language.rs
@@ -23,28 +23,30 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, AcceptLanguage, LanguageTag, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptLanguage, LanguageTag, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     /// let mut langtag: LanguageTag = Default::default();
     /// langtag.language = Some("en".to_owned());
     /// langtag.region = Some("US".to_owned());
-    /// headers.set(
-    ///     AcceptLanguage(vec![
+    /// headers.encode(
+    ///     &AcceptLanguage(vec![
     ///         qitem(langtag),
     ///     ])
     /// );
     /// ```
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # #[macro_use] extern crate language_tags;
-    /// # use hyperx::header::{Headers, AcceptLanguage, QualityItem, q, qitem};
+    /// # use hyperx::header::{AcceptLanguage, QualityItem, q, qitem, TypedHeaders};
     /// #
     /// # fn main() {
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptLanguage(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptLanguage(vec![
     ///         qitem(langtag!(da)),
     ///         QualityItem::new(langtag!(en;;;GB), q(800)),
     ///         QualityItem::new(langtag!(en), q(700)),

--- a/src/header/common/accept_ranges.rs
+++ b/src/header/common/accept_ranges.rs
@@ -22,25 +22,28 @@ header! {
     ///
     /// # Examples
     /// ```
-    /// use hyperx::header::{Headers, AcceptRanges, RangeUnit};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptRanges, RangeUnit, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(AcceptRanges(vec![RangeUnit::Bytes]));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&AcceptRanges(vec![RangeUnit::Bytes]));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, AcceptRanges, RangeUnit};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptRanges, RangeUnit, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(AcceptRanges(vec![RangeUnit::None]));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&AcceptRanges(vec![RangeUnit::None]));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, AcceptRanges, RangeUnit};
+    /// # extern crate http;
+    /// use hyperx::header::{AcceptRanges, RangeUnit, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AcceptRanges(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AcceptRanges(vec![
     ///         RangeUnit::Unregistered("nibbles".to_owned()),
     ///         RangeUnit::Bytes,
     ///         RangeUnit::Unregistered("doublets".to_owned()),

--- a/src/header/common/access_control_allow_credentials.rs
+++ b/src/header/common/access_control_allow_credentials.rs
@@ -28,13 +28,14 @@ use header::{Header, RawLike};
 /// # Examples
 ///
 /// ```
+/// # extern crate http;
 /// # extern crate hyperx;
 /// # fn main() {
 ///
-/// use hyperx::header::{Headers, AccessControlAllowCredentials};
+/// use hyperx::header::{AccessControlAllowCredentials, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(AccessControlAllowCredentials);
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&AccessControlAllowCredentials);
 /// # }
 /// ```
 #[derive(Clone, PartialEq, Debug)]

--- a/src/header/common/access_control_allow_headers.rs
+++ b/src/header/common/access_control_allow_headers.rs
@@ -20,33 +20,35 @@ header! {
     /// # Examples
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, AccessControlAllowHeaders};
+    /// use hyperx::header::{AccessControlAllowHeaders, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlAllowHeaders(vec![Ascii::new("date".to_owned())])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlAllowHeaders(vec![Ascii::new("date".to_owned())])
     /// );
     /// # }
     /// ```
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, AccessControlAllowHeaders};
+    /// use hyperx::header::{AccessControlAllowHeaders, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlAllowHeaders(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlAllowHeaders(vec![
     ///         Ascii::new("accept-language".to_owned()),
     ///         Ascii::new("date".to_owned()),
     ///     ])

--- a/src/header/common/access_control_allow_methods.rs
+++ b/src/header/common/access_control_allow_methods.rs
@@ -20,22 +20,24 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, AccessControlAllowMethods};
+    /// # extern crate http;
+    /// use hyperx::header::{AccessControlAllowMethods, TypedHeaders};
     /// use hyperx::Method;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlAllowMethods(vec![Method::Get])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlAllowMethods(vec![Method::Get])
     /// );
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, AccessControlAllowMethods};
+    /// # extern crate http;
+    /// use hyperx::header::{AccessControlAllowMethods, TypedHeaders};
     /// use hyperx::Method;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlAllowMethods(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlAllowMethods(vec![
     ///         Method::Get,
     ///         Method::Post,
     ///         Method::Patch,

--- a/src/header/common/access_control_allow_origin.rs
+++ b/src/header/common/access_control_allow_origin.rs
@@ -23,27 +23,30 @@ use header::{Header, RawLike};
 ///
 /// # Examples
 /// ```
-/// use hyperx::header::{Headers, AccessControlAllowOrigin};
+/// # extern crate http;
+/// use hyperx::header::{AccessControlAllowOrigin, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     AccessControlAllowOrigin::Any
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &AccessControlAllowOrigin::Any
 /// );
 /// ```
 /// ```
-/// use hyperx::header::{Headers, AccessControlAllowOrigin};
+/// # extern crate http;
+/// use hyperx::header::{AccessControlAllowOrigin, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     AccessControlAllowOrigin::Null,
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &AccessControlAllowOrigin::Null,
 /// );
 /// ```
 /// ```
-/// use hyperx::header::{Headers, AccessControlAllowOrigin};
+/// # extern crate http;
+/// use hyperx::header::{AccessControlAllowOrigin, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     AccessControlAllowOrigin::Value("http://hyper.rs".to_owned())
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &AccessControlAllowOrigin::Value("http://hyper.rs".to_owned())
 /// );
 /// ```
 #[derive(Clone, PartialEq, Debug)]

--- a/src/header/common/access_control_expose_headers.rs
+++ b/src/header/common/access_control_expose_headers.rs
@@ -19,17 +19,18 @@ header! {
     /// # Examples
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, AccessControlExposeHeaders};
+    /// use hyperx::header::{AccessControlExposeHeaders, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlExposeHeaders(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlExposeHeaders(vec![
     ///         Ascii::new("etag".to_owned()),
     ///         Ascii::new("content-length".to_owned())
     ///     ])
@@ -38,17 +39,18 @@ header! {
     /// ```
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, AccessControlExposeHeaders};
+    /// use hyperx::header::{AccessControlExposeHeaders, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlExposeHeaders(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlExposeHeaders(vec![
     ///         Ascii::new("etag".to_owned()),
     ///         Ascii::new("content-length".to_owned())
     ///     ])

--- a/src/header/common/access_control_max_age.rs
+++ b/src/header/common/access_control_max_age.rs
@@ -18,10 +18,11 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, AccessControlMaxAge};
+    /// # extern crate http;
+    /// use hyperx::header::{AccessControlMaxAge, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(AccessControlMaxAge(1728000u32));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&AccessControlMaxAge(1728000u32));
     /// ```
     (AccessControlMaxAge, "Access-Control-Max-Age") => [u32]
 

--- a/src/header/common/access_control_request_headers.rs
+++ b/src/header/common/access_control_request_headers.rs
@@ -20,33 +20,35 @@ header! {
     /// # Examples
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, AccessControlRequestHeaders};
+    /// use hyperx::header::{AccessControlRequestHeaders, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlRequestHeaders(vec![Ascii::new("date".to_owned())])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlRequestHeaders(vec![Ascii::new("date".to_owned())])
     /// );
     /// # }
     /// ```
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, AccessControlRequestHeaders};
+    /// use hyperx::header::{AccessControlRequestHeaders, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     AccessControlRequestHeaders(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &AccessControlRequestHeaders(vec![
     ///         Ascii::new("accept-language".to_owned()),
     ///         Ascii::new("date".to_owned()),
     ///     ])

--- a/src/header/common/access_control_request_method.rs
+++ b/src/header/common/access_control_request_method.rs
@@ -18,11 +18,12 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, AccessControlRequestMethod};
+    /// # extern crate http;
+    /// use hyperx::header::{AccessControlRequestMethod, TypedHeaders};
     /// use hyperx::Method;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(AccessControlRequestMethod(Method::Get));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&AccessControlRequestMethod(Method::Get));
     /// ```
     (AccessControlRequestMethod, "Access-Control-Request-Method") => [Method]
 

--- a/src/header/common/allow.rs
+++ b/src/header/common/allow.rs
@@ -22,22 +22,24 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, Allow};
+    /// # extern crate http;
+    /// use hyperx::header::{Allow, TypedHeaders};
     /// use hyperx::Method;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Allow(vec![Method::Get])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Allow(vec![Method::Get])
     /// );
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Allow};
+    /// # extern crate http;
+    /// use hyperx::header::{Allow, TypedHeaders};
     /// use hyperx::Method;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Allow(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Allow(vec![
     ///         Method::Get,
     ///         Method::Post,
     ///         Method::Patch,

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -230,8 +230,12 @@ impl FromStr for Bearer {
 #[cfg(test)]
 mod tests {
     use super::{Authorization, Basic, Bearer};
-    use super::super::super::{Headers, Header, Raw};
+    use super::super::super::{Header, Raw};
 
+    #[cfg(feature = "headers")]
+    use super::super::super::Headers;
+
+    #[cfg(feature = "headers")]
     #[test]
     fn test_raw_auth() {
         let mut headers = Headers::new();
@@ -246,6 +250,7 @@ mod tests {
         assert_eq!(header.0, "foo bar baz");
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_basic_auth() {
         let mut headers = Headers::new();
@@ -256,6 +261,7 @@ mod tests {
             "Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n".to_owned());
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_basic_auth_no_password() {
         let mut headers = Headers::new();
@@ -279,6 +285,7 @@ mod tests {
         assert_eq!(auth.0.password, Some("".to_owned()));
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_bearer_auth() {
         let mut headers = Headers::new();

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -26,17 +26,19 @@ use header::{Header, RawLike};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Authorization};
+/// # extern crate http;
+/// use hyperx::header::{Authorization, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(Authorization("let me in".to_owned()));
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&Authorization("let me in".to_owned()));
 /// ```
 /// ```
-/// use hyperx::header::{Headers, Authorization, Basic};
+/// # extern crate http;
+/// use hyperx::header::{Authorization, Basic, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///    Authorization(
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///    &Authorization(
 ///        Basic {
 ///            username: "Aladdin".to_owned(),
 ///            password: Some("open sesame".to_owned())
@@ -46,11 +48,11 @@ use header::{Header, RawLike};
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, Authorization, Bearer};
+/// use hyperx::header::{Authorization, Bearer, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///    Authorization(
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///    &Authorization(
 ///        Bearer {
 ///            token: "QWxhZGRpbjpvcGVuIHNlc2FtZQ".to_owned()
 ///        }

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -311,7 +311,7 @@ bench_header!(basic, Authorization<Basic>, { vec![b"Basic QWxhZGRpbjpuIHNlc2FtZQ
 bench_header!(bearer, Authorization<Bearer>, { vec![b"Bearer fpKL54jvWmEGVoRdCNjG".to_vec()] });
 
 impl<S> ::header::StandardHeader for Authorization<S>
-    where S: Scheme + Any + ::std::fmt::Display
+    where S: Scheme + Any
 {
     #[inline]
     fn http_header_name() -> ::http::header::HeaderName {

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -301,7 +301,6 @@ bench_header!(raw, Authorization<String>, { vec![b"foo bar baz".to_vec()] });
 bench_header!(basic, Authorization<Basic>, { vec![b"Basic QWxhZGRpbjpuIHNlc2FtZQ==".to_vec()] });
 bench_header!(bearer, Authorization<Bearer>, { vec![b"Bearer fpKL54jvWmEGVoRdCNjG".to_vec()] });
 
-#[cfg(feature = "compat")]
 impl<S> ::header::StandardHeader for Authorization<S>
     where S: Scheme + Any + ::std::fmt::Display
 {

--- a/src/header/common/cache_control.rs
+++ b/src/header/common/cache_control.rs
@@ -25,20 +25,22 @@ use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 ///
 /// # Examples
 /// ```
-/// use hyperx::header::{Headers, CacheControl, CacheDirective};
+/// # extern crate http;
+/// use hyperx::header::{CacheControl, CacheDirective, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     CacheControl(vec![CacheDirective::MaxAge(86400u32)])
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &CacheControl(vec![CacheDirective::MaxAge(86400u32)])
 /// );
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, CacheControl, CacheDirective};
+/// # extern crate http;
+/// use hyperx::header::{CacheControl, CacheDirective, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     CacheControl(vec![
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &CacheControl(vec![
 ///         CacheDirective::NoCache,
 ///         CacheDirective::Private,
 ///         CacheDirective::MaxAge(360u32),

--- a/src/header/common/connection.rs
+++ b/src/header/common/connection.rs
@@ -73,24 +73,26 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, Connection};
+    /// # extern crate http;
+    /// use hyperx::header::{Connection, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Connection::keep_alive());
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Connection::keep_alive());
     /// ```
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, Connection, ConnectionOption};
+    /// use hyperx::header::{Connection, ConnectionOption, TypedHeaders};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Connection(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Connection(vec![
     ///         ConnectionOption::ConnectionHeader(Ascii::new("upgrade".to_owned())),
     ///     ])
     /// );

--- a/src/header/common/content_disposition.rs
+++ b/src/header/common/content_disposition.rs
@@ -69,10 +69,11 @@ pub enum DispositionParam {
 /// # Example
 ///
 /// ```
-/// use hyperx::header::{Headers, ContentDisposition, DispositionType, DispositionParam, Charset};
+/// # extern crate http;
+/// use hyperx::header::{ContentDisposition, DispositionType, DispositionParam, Charset, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(ContentDisposition {
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&ContentDisposition {
 ///     disposition: DispositionType::Attachment,
 ///     parameters: vec![DispositionParam::Filename(
 ///       Charset::Iso_8859_1, // The character set for the bytes of the filename

--- a/src/header/common/content_encoding.rs
+++ b/src/header/common/content_encoding.rs
@@ -25,18 +25,20 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, ContentEncoding, Encoding};
+    /// # extern crate http;
+    /// use hyperx::header::{ContentEncoding, Encoding, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(ContentEncoding(vec![Encoding::Chunked]));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&ContentEncoding(vec![Encoding::Chunked]));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, ContentEncoding, Encoding};
+    /// # extern crate http;
+    /// use hyperx::header::{ContentEncoding, Encoding, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     ContentEncoding(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &ContentEncoding(vec![
     ///         Encoding::Gzip,
     ///         Encoding::Chunked,
     ///     ])

--- a/src/header/common/content_language.rs
+++ b/src/header/common/content_language.rs
@@ -24,14 +24,15 @@ header! {
     /// # Examples
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # #[macro_use] extern crate language_tags;
-    /// # use hyperx::header::{Headers, ContentLanguage, qitem};
+    /// # use hyperx::header::{ContentLanguage, qitem, TypedHeaders};
     /// #
     /// # fn main() {
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     ContentLanguage(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &ContentLanguage(vec![
     ///         qitem(langtag!(en)),
     ///     ])
     /// );
@@ -39,15 +40,16 @@ header! {
     /// ```
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # #[macro_use] extern crate language_tags;
-    /// # use hyperx::header::{Headers, ContentLanguage, qitem};
+    /// # use hyperx::header::{ContentLanguage, qitem, TypedHeaders};
     /// #
     /// # fn main() {
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     ContentLanguage(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &ContentLanguage(vec![
     ///         qitem(langtag!(da)),
     ///         qitem(langtag!(en;;;GB)),
     ///     ])

--- a/src/header/common/content_length.rs
+++ b/src/header/common/content_length.rs
@@ -34,10 +34,11 @@ use header::{Header, RawLike, parsing};
 /// # Example
 ///
 /// ```
-/// use hyperx::header::{Headers, ContentLength};
+/// # extern crate http;
+/// use hyperx::header::{ContentLength, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(ContentLength(1024u64));
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&ContentLength(1024u64));
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ContentLength(pub u64);

--- a/src/header/common/content_location.rs
+++ b/src/header/common/content_location.rs
@@ -24,17 +24,19 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, ContentLocation};
+    /// # extern crate http;
+    /// use hyperx::header::{ContentLocation, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(ContentLocation("/hypertext/Overview.html".to_owned()));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&ContentLocation("/hypertext/Overview.html".to_owned()));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, ContentLocation};
+    /// # extern crate http;
+    /// use hyperx::header::{ContentLocation, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(ContentLocation("http://www.example.org/hypertext/Overview.html".to_owned()));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&ContentLocation("http://www.example.org/hypertext/Overview.html".to_owned()));
     /// ```
     // TODO: use URL
     (ContentLocation, "Content-Location") => [String]

--- a/src/header/common/content_type.rs
+++ b/src/header/common/content_type.rs
@@ -30,23 +30,25 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, ContentType};
+    /// # extern crate http;
+    /// use hyperx::header::{ContentType, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     ///
-    /// headers.set(
-    ///     ContentType::json()
+    /// headers.encode(
+    ///     &ContentType::json()
     /// );
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, ContentType};
+    /// # extern crate http;
+    /// use hyperx::header::{ContentType, TypedHeaders};
     /// use hyperx::mime;
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     ///
-    /// headers.set(
-    ///     ContentType(mime::TEXT_HTML)
+    /// headers.encode(
+    ///     &ContentType(mime::TEXT_HTML)
     /// );
     /// ```
     (ContentType, "Content-Type") => danger [Mime]

--- a/src/header/common/cookie.rs
+++ b/src/header/common/cookie.rs
@@ -20,15 +20,16 @@ use header::internals::VecMap;
 ///
 /// # Example
 /// ```
-/// use hyperx::header::{Headers, Cookie};
+/// # extern crate http;
+/// use hyperx::header::{Cookie, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
+/// let mut headers = http::HeaderMap::new();
 /// let mut cookie = Cookie::new();
 /// cookie.append("foo", "bar");
 ///
 /// assert_eq!(cookie.get("foo"), Some("bar"));
 ///
-/// headers.set(cookie);
+/// headers.encode(&cookie);
 /// ```
 #[derive(Clone)]
 pub struct Cookie(VecMap<Cow<'static, str>, Cow<'static, str>>);

--- a/src/header/common/date.rs
+++ b/src/header/common/date.rs
@@ -19,11 +19,12 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, Date};
+    /// # extern crate http;
+    /// use hyperx::header::{Date, TypedHeaders};
     /// use std::time::SystemTime;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Date(SystemTime::now().into()));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Date(SystemTime::now().into()));
     /// ```
     (Date, "Date") => [HttpDate]
 

--- a/src/header/common/etag.rs
+++ b/src/header/common/etag.rs
@@ -28,16 +28,18 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, ETag, EntityTag};
+    /// # extern crate http;
+    /// use hyperx::header::{ETag, EntityTag, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(ETag(EntityTag::new(false, "xyzzy".to_owned())));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&ETag(EntityTag::new(false, "xyzzy".to_owned())));
     /// ```
     /// ```
-    /// use hyperx::header::{Headers, ETag, EntityTag};
+    /// # extern crate http;
+    /// use hyperx::header::{ETag, EntityTag, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(ETag(EntityTag::new(true, "xyzzy".to_owned())));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&ETag(EntityTag::new(true, "xyzzy".to_owned())));
     /// ```
     (ETag, "ETag") => [EntityTag]
 

--- a/src/header/common/expect.rs
+++ b/src/header/common/expect.rs
@@ -16,9 +16,10 @@ use header::{Header, RawLike};
 ///
 /// # Example
 /// ```
-/// use hyperx::header::{Headers, Expect};
-/// let mut headers = Headers::new();
-/// headers.set(Expect::Continue);
+/// # extern crate http;
+/// use hyperx::header::{Expect, TypedHeaders};
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&Expect::Continue);
 /// ```
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum Expect {

--- a/src/header/common/expires.rs
+++ b/src/header/common/expires.rs
@@ -22,12 +22,13 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, Expires};
+    /// # extern crate http;
+    /// use hyperx::header::{Expires, TypedHeaders};
     /// use std::time::{SystemTime, Duration};
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     /// let expiration = SystemTime::now() + Duration::from_secs(60 * 60 * 24);
-    /// headers.set(Expires(expiration.into()));
+    /// headers.encode(&Expires(expiration.into()));
     /// ```
     (Expires, "Expires") => [HttpDate]
 

--- a/src/header/common/from.rs
+++ b/src/header/common/from.rs
@@ -15,10 +15,11 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, From};
+    /// # extern crate http;
+    /// use hyperx::header::{From, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(From("webmaster@example.org".to_owned()));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&From("webmaster@example.org".to_owned()));
     /// ```
     // FIXME: Maybe use mailbox?
     (From, "From") => [String]

--- a/src/header/common/host.rs
+++ b/src/header/common/host.rs
@@ -12,21 +12,21 @@ use header::parsing::from_one_raw_str;
 ///
 /// # Examples
 /// ```
-/// use hyperx::header::{Headers, Host};
+/// # extern crate http;
+/// use hyperx::header::{Host, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Host::new("hyper.rs", None)
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Host::new("hyper.rs", None)
 /// );
 /// ```
 /// ```
-/// use hyperx::header::{Headers, Host};
+/// # extern crate http;
+/// use hyperx::header::{Host, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     // In Rust 1.12+
-///     // Host::new("hyper.rs", 8080)
-///     Host::new("hyper.rs", Some(8080))
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Host::new("hyper.rs", 8080)
 /// );
 /// ```
 #[derive(Clone, PartialEq, Debug)]

--- a/src/header/common/if_match.rs
+++ b/src/header/common/if_match.rs
@@ -30,18 +30,20 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, IfMatch};
+    /// # extern crate http;
+    /// use hyperx::header::{IfMatch, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(IfMatch::Any);
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&IfMatch::Any);
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, IfMatch, EntityTag};
+    /// # extern crate http;
+    /// use hyperx::header::{IfMatch, EntityTag, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     IfMatch::Items(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &IfMatch::Items(vec![
     ///         EntityTag::new(false, "xyzzy".to_owned()),
     ///         EntityTag::new(false, "foobar".to_owned()),
     ///         EntityTag::new(false, "bazquux".to_owned()),

--- a/src/header/common/if_modified_since.rs
+++ b/src/header/common/if_modified_since.rs
@@ -22,12 +22,13 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, IfModifiedSince};
+    /// # extern crate http;
+    /// use hyperx::header::{IfModifiedSince, TypedHeaders};
     /// use std::time::{SystemTime, Duration};
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     /// let modified = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
-    /// headers.set(IfModifiedSince(modified.into()));
+    /// headers.encode(&IfModifiedSince(modified.into()));
     /// ```
     (IfModifiedSince, "If-Modified-Since") => [HttpDate]
 

--- a/src/header/common/if_none_match.rs
+++ b/src/header/common/if_none_match.rs
@@ -32,18 +32,20 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, IfNoneMatch};
+    /// # extern crate http;
+    /// use hyperx::header::{IfNoneMatch, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(IfNoneMatch::Any);
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&IfNoneMatch::Any);
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, IfNoneMatch, EntityTag};
+    /// # extern crate http;
+    /// use hyperx::header::{IfNoneMatch, EntityTag, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     IfNoneMatch::Items(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &IfNoneMatch::Items(vec![
     ///         EntityTag::new(false, "xyzzy".to_owned()),
     ///         EntityTag::new(false, "foobar".to_owned()),
     ///         EntityTag::new(false, "bazquux".to_owned()),

--- a/src/header/common/if_range.rs
+++ b/src/header/common/if_range.rs
@@ -30,19 +30,21 @@ use header::{self, Header, RawLike, EntityTag, HttpDate};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, IfRange, EntityTag};
+/// # extern crate http;
+/// use hyperx::header::{IfRange, EntityTag, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(IfRange::EntityTag(EntityTag::new(false, "xyzzy".to_owned())));
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&IfRange::EntityTag(EntityTag::new(false, "xyzzy".to_owned())));
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, IfRange};
+/// # extern crate http;
+/// use hyperx::header::{IfRange, TypedHeaders};
 /// use std::time::{SystemTime, Duration};
 ///
-/// let mut headers = Headers::new();
+/// let mut headers = http::HeaderMap::new();
 /// let fetched = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
-/// headers.set(IfRange::Date(fetched.into()));
+/// headers.encode(&IfRange::Date(fetched.into()));
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub enum IfRange {

--- a/src/header/common/if_unmodified_since.rs
+++ b/src/header/common/if_unmodified_since.rs
@@ -23,12 +23,13 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, IfUnmodifiedSince};
+    /// # extern crate http;
+    /// use hyperx::header::{IfUnmodifiedSince, TypedHeaders};
     /// use std::time::{SystemTime, Duration};
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     /// let modified = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
-    /// headers.set(IfUnmodifiedSince(modified.into()));
+    /// headers.encode(&IfUnmodifiedSince(modified.into()));
     /// ```
     (IfUnmodifiedSince, "If-Unmodified-Since") => [HttpDate]
 

--- a/src/header/common/last_event_id.rs
+++ b/src/header/common/last_event_id.rs
@@ -16,10 +16,14 @@ use header::{self, Header, RawLike};
 ///
 /// # Example
 /// ```
-/// use hyperx::header::{Headers, LastEventId};
+/// # extern crate http;
+/// use hyperx::header::LastEventId;
 ///
-/// let mut headers = Headers::new();
-/// headers.set(LastEventId("1".to_owned()));
+/// let mut headers = http::HeaderMap::new();
+/// headers.insert(
+///     "last-event-id",
+///     LastEventId("1".to_owned()).to_string().parse().unwrap()
+/// );
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct LastEventId(pub String);

--- a/src/header/common/last_modified.rs
+++ b/src/header/common/last_modified.rs
@@ -22,12 +22,13 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, LastModified};
+    /// # extern crate http;
+    /// use hyperx::header::{LastModified, TypedHeaders};
     /// use std::time::{SystemTime, Duration};
     ///
-    /// let mut headers = Headers::new();
+    /// let mut headers = http::HeaderMap::new();
     /// let modified = SystemTime::now() - Duration::from_secs(60 * 60 * 24);
-    /// headers.set(LastModified(modified.into()));
+    /// headers.encode(&LastModified(modified.into()));
     /// ```
     (LastModified, "Last-Modified") => [HttpDate]
 

--- a/src/header/common/link.rs
+++ b/src/header/common/link.rs
@@ -58,15 +58,16 @@ use header::{Header, RawLike};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Link, LinkValue, RelationType};
+/// # extern crate http;
+/// use hyperx::header::{Link, LinkValue, RelationType, TypedHeaders};
 ///
 /// let link_value = LinkValue::new("http://example.com/TheBook/chapter2")
 ///     .push_rel(RelationType::Previous)
 ///     .set_title("previous chapter");
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Link::new(vec![link_value])
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Link::new(vec![link_value])
 /// );
 /// ```
 #[derive(Clone, PartialEq, Debug)]

--- a/src/header/common/location.rs
+++ b/src/header/common/location.rs
@@ -20,17 +20,19 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, Location};
+    /// # extern crate http;
+    /// use hyperx::header::{Location, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Location::new("/People.html#tim"));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Location::new("/People.html#tim"));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Location};
+    /// # extern crate http;
+    /// use hyperx::header::{Location, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Location::new("http://www.example.com/index.html"));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Location::new("http://www.example.com/index.html"));
     /// ```
     // TODO: Use URL
     (Location, "Location") => Cow[str]

--- a/src/header/common/mod.rs
+++ b/src/header/common/mod.rs
@@ -459,7 +459,6 @@ macro_rules! header {
 #[macro_export]
 macro_rules! standard_header {
     ($local:ident, $hname:ident) => {
-        #[cfg(feature = "compat")]
         impl $crate::header::StandardHeader for $local {
             #[inline]
             fn http_header_name() -> ::http::header::HeaderName {

--- a/src/header/common/origin.rs
+++ b/src/header/common/origin.rs
@@ -17,20 +17,22 @@ use header::parsing::from_one_raw_str;
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Origin};
+/// # extern crate http;
+/// use hyperx::header::{Origin, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Origin::new("http", "hyper.rs", None)
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Origin::new("http", "hyper.rs", None)
 /// );
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, Origin};
+/// # extern crate http;
+/// use hyperx::header::{Origin, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Origin::new("https", "wikipedia.org", Some(443))
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Origin::new("https", "wikipedia.org", Some(443))
 /// );
 /// ```
 #[derive(PartialEq, Clone, Debug)]

--- a/src/header/common/pragma.rs
+++ b/src/header/common/pragma.rs
@@ -22,17 +22,19 @@ use header::{Header, RawLike, parsing};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Pragma};
+/// # extern crate http;
+/// use hyperx::header::{Pragma, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(Pragma::NoCache);
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&Pragma::NoCache);
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, Pragma};
+/// # extern crate http;
+/// use hyperx::header::{Pragma, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(Pragma::Ext("foobar".to_owned()));
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&Pragma::Ext("foobar".to_owned()));
 /// ```
 #[derive(Clone, PartialEq, Debug)]
 pub enum Pragma {

--- a/src/header/common/prefer.rs
+++ b/src/header/common/prefer.rs
@@ -25,19 +25,23 @@ use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Prefer, Preference};
+/// # extern crate http;
+/// use hyperx::header::{Prefer, Preference, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Prefer(vec![Preference::RespondAsync])
+/// let mut headers = http::HeaderMap::new();
+/// headers.insert(
+///     "prefer",
+///     Prefer(vec![Preference::RespondAsync]).to_string().parse().unwrap()
 /// );
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, Prefer, Preference};
+/// # extern crate http;
+/// use hyperx::header::{Prefer, Preference, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
+/// let mut headers = http::HeaderMap::new();
+/// headers.insert(
+///     "prefer",
 ///     Prefer(vec![
 ///         Preference::RespondAsync,
 ///         Preference::ReturnRepresentation,
@@ -45,7 +49,7 @@ use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 ///         Preference::Extension("foo".to_owned(),
 ///                               "bar".to_owned(),
 ///                               vec![]),
-///     ])
+///     ]).to_string().parse().unwrap()
 /// );
 /// ```
 #[derive(PartialEq, Clone, Debug)]

--- a/src/header/common/preference_applied.rs
+++ b/src/header/common/preference_applied.rs
@@ -24,19 +24,25 @@ use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, PreferenceApplied, Preference};
+/// # extern crate http;
+/// use hyperx::header::{PreferenceApplied, Preference, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     PreferenceApplied(vec![Preference::RespondAsync])
+/// let mut headers = http::HeaderMap::new();
+/// headers.insert(
+///     "preference-applied",
+///     PreferenceApplied(vec![
+///         Preference::RespondAsync
+///     ]).to_string().parse().unwrap()
 /// );
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, PreferenceApplied, Preference};
+/// # extern crate http;
+/// use hyperx::header::{PreferenceApplied, Preference, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
+/// let mut headers = http::HeaderMap::new();
+/// headers.insert(
+///     "preference-applied",
 ///     PreferenceApplied(vec![
 ///         Preference::RespondAsync,
 ///         Preference::ReturnRepresentation,
@@ -44,7 +50,7 @@ use header::parsing::{from_comma_delimited, fmt_comma_delimited};
 ///         Preference::Extension("foo".to_owned(),
 ///                               "bar".to_owned(),
 ///                               vec![]),
-///     ])
+///     ]).to_string().parse().unwrap()
 /// );
 /// ```
 #[derive(PartialEq, Clone, Debug)]

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -122,8 +122,12 @@ impl<S: Scheme> fmt::Display for ProxyAuthorization<S> {
 #[cfg(test)]
 mod tests {
     use super::ProxyAuthorization;
-    use super::super::super::{Headers, Header, Raw, Basic, Bearer};
+    use super::super::super::{Header, Raw, Basic, Bearer};
 
+    #[cfg(feature = "headers")]
+    use super::super::super::Headers;
+
+    #[cfg(feature = "headers")]
     #[test]
     fn test_raw_auth() {
         let mut headers = Headers::new();
@@ -138,6 +142,7 @@ mod tests {
         assert_eq!(header.0, "foo bar baz");
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_basic_auth() {
         let mut headers = Headers::new();
@@ -148,6 +153,7 @@ mod tests {
             "Proxy-Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\r\n".to_owned());
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_basic_auth_no_password() {
         let mut headers = Headers::new();
@@ -171,6 +177,7 @@ mod tests {
         assert_eq!(auth.0.password, Some("".to_owned()));
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_bearer_auth() {
         let mut headers = Headers::new();

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -211,7 +211,7 @@ mod benches {
 }
 
 impl<S> ::header::StandardHeader for ProxyAuthorization<S>
-    where S: Scheme + Any + ::std::fmt::Display
+    where S: Scheme + Any
 {
     #[inline]
     fn http_header_name() -> ::http::header::HeaderName {

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -26,17 +26,19 @@ use header::{Header, RawLike, Scheme};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, ProxyAuthorization};
+/// # extern crate http;
+/// use hyperx::header::{ProxyAuthorization, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(ProxyAuthorization("let me in".to_owned()));
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&ProxyAuthorization("let me in".to_owned()));
 /// ```
 /// ```
-/// use hyperx::header::{Headers, ProxyAuthorization, Basic};
+/// # extern crate http;
+/// use hyperx::header::{ProxyAuthorization, Basic, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///    ProxyAuthorization(
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///    &ProxyAuthorization(
 ///        Basic {
 ///            username: "Aladdin".to_owned(),
 ///            password: Some("open sesame".to_owned())
@@ -46,11 +48,12 @@ use header::{Header, RawLike, Scheme};
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, ProxyAuthorization, Bearer};
+/// # extern crate http;
+/// use hyperx::header::{ProxyAuthorization, Bearer, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///    ProxyAuthorization(
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///    &ProxyAuthorization(
 ///        Bearer {
 ///            token: "QWxhZGRpbjpvcGVuIHNlc2FtZQ".to_owned()
 ///        }

--- a/src/header/common/proxy_authorization.rs
+++ b/src/header/common/proxy_authorization.rs
@@ -200,7 +200,6 @@ mod benches {
     bench_header!(bearer, ProxyAuthorization<Bearer>, { vec![b"Bearer fpKL54jvWmEGVoRdCNjG".to_vec()] });
 }
 
-#[cfg(feature = "compat")]
 impl<S> ::header::StandardHeader for ProxyAuthorization<S>
     where S: Scheme + Any + ::std::fmt::Display
 {

--- a/src/header/common/range.rs
+++ b/src/header/common/range.rs
@@ -39,25 +39,27 @@ use header::parsing::{from_one_raw_str};
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Range, ByteRangeSpec};
+/// # extern crate http;
+/// use hyperx::header::{Range, ByteRangeSpec, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(Range::Bytes(
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&Range::Bytes(
 ///     vec![ByteRangeSpec::FromTo(1, 100), ByteRangeSpec::AllFrom(200)]
 /// ));
 ///
 /// headers.clear();
-/// headers.set(Range::Unregistered("letters".to_owned(), "a-f".to_owned()));
+/// headers.encode(&Range::Unregistered("letters".to_owned(), "a-f".to_owned()));
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, Range};
+/// # extern crate http;
+/// use hyperx::header::{Range, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(Range::bytes(1, 100));
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&Range::bytes(1, 100));
 ///
 /// headers.clear();
-/// headers.set(Range::bytes_multi(vec![(1, 100), (200, 300)]));
+/// headers.encode(&Range::bytes_multi(vec![(1, 100), (200, 300)]));
 /// ```
 #[derive(PartialEq, Clone, Debug)]
 pub enum Range {

--- a/src/header/common/range.rs
+++ b/src/header/common/range.rs
@@ -362,6 +362,7 @@ mod tests {
         assert_eq!(r.ok(), None);
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_fmt() {
         use header::Headers;

--- a/src/header/common/referer.rs
+++ b/src/header/common/referer.rs
@@ -21,17 +21,19 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, Referer};
+    /// # extern crate http;
+    /// use hyperx::header::{Referer, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Referer::new("/People.html#tim"));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Referer::new("/People.html#tim"));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Referer};
+    /// # extern crate http;
+    /// use hyperx::header::{Referer, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Referer::new("http://www.example.com/index.html"));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Referer::new("http://www.example.com/index.html"));
     /// ```
     // TODO Use URL
     (Referer, "Referer") => Cow[str]

--- a/src/header/common/referrer_policy.rs
+++ b/src/header/common/referrer_policy.rs
@@ -29,10 +29,11 @@ use header::{Header, RawLike, parsing};
 /// # Example
 ///
 /// ```
-/// use hyperx::header::{Headers, ReferrerPolicy};
+/// # extern crate http;
+/// use hyperx::header::{ReferrerPolicy, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(ReferrerPolicy::NoReferrer);
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(&ReferrerPolicy::NoReferrer);
 /// ```
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ReferrerPolicy {

--- a/src/header/common/retry_after.rs
+++ b/src/header/common/retry_after.rs
@@ -53,22 +53,24 @@ use header::shared::HttpDate;
 ///
 /// # Examples
 /// ```
+/// # extern crate http;
 /// use std::time::Duration;
-/// use hyperx::header::{Headers, RetryAfter};
+/// use hyperx::header::{RetryAfter, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     RetryAfter::Delay(Duration::from_secs(300))
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &RetryAfter::Delay(Duration::from_secs(300))
 /// );
 /// ```
 /// ```
+/// # extern crate http;
 /// use std::time::{SystemTime, Duration};
-/// use hyperx::header::{Headers, RetryAfter};
+/// use hyperx::header::{RetryAfter, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
+/// let mut headers = http::HeaderMap::new();
 /// let date = SystemTime::now() + Duration::from_secs(300);
-/// headers.set(
-///     RetryAfter::DateTime(date.into())
+/// headers.encode(
+///     &RetryAfter::DateTime(date.into())
 /// );
 /// ```
 

--- a/src/header/common/server.rs
+++ b/src/header/common/server.rs
@@ -21,10 +21,11 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, Server};
+    /// # extern crate http;
+    /// use hyperx::header::{Server, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Server::new("hyper/0.5.2"));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Server::new("hyper/0.5.2"));
     /// ```
     // TODO: Maybe parse as defined in the spec?
     (Server, "Server") => Cow[str]

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -60,15 +60,16 @@ use std::str::from_utf8;
 /// # Example
 ///
 /// ```
-/// use hyperx::header::{Headers, SetCookie};
+/// # extern crate http;
+/// use hyperx::header::{SetCookie, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
+/// let mut headers = http::HeaderMap::new();
 ///
-/// headers.set(
-///     SetCookie(vec![
-///         String::from("foo=bar; Path=/path; Domain=example.com")
-///     ])
+/// headers.append(
+///     http::header::SET_COOKIE,
+///     "foo=bar; Path=/path; Domain=example.com".parse().unwrap()
 /// );
+/// let cookie: SetCookie = headers.decode().unwrap();
 /// ```
 #[derive(Clone, PartialEq, Debug)]
 pub struct SetCookie(pub Vec<String>);

--- a/src/header/common/set_cookie.rs
+++ b/src/header/common/set_cookie.rs
@@ -106,6 +106,7 @@ impl Header for SetCookie {
     }
 }
 
+#[cfg(feature = "headers")]
 #[test]
 fn test_set_cookie_fmt() {
     use ::header::Headers;

--- a/src/header/common/strict_transport_security.rs
+++ b/src/header/common/strict_transport_security.rs
@@ -34,14 +34,15 @@ use header::{Header, RawLike, parsing};
 /// # Example
 ///
 /// ```
+/// # extern crate http;
 /// # extern crate hyperx;
 /// # fn main() {
-/// use hyperx::header::{Headers, StrictTransportSecurity};
+/// use hyperx::header::{StrictTransportSecurity, TypedHeaders};
 ///
-/// let mut headers = Headers::new();
+/// let mut headers = http::HeaderMap::new();
 ///
-/// headers.set(
-///    StrictTransportSecurity::including_subdomains(31536000u64)
+/// headers.encode(
+///    &StrictTransportSecurity::including_subdomains(31536000u64)
 /// );
 /// # }
 /// ```

--- a/src/header/common/te.rs
+++ b/src/header/common/te.rs
@@ -27,20 +27,22 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, Te, Encoding, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{Te, Encoding, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Te(vec![qitem(Encoding::Trailers)])
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Te(vec![qitem(Encoding::Trailers)])
     /// );
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Te, Encoding, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{Te, Encoding, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Te(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Te(vec![
     ///         qitem(Encoding::Trailers),
     ///         qitem(Encoding::Gzip),
     ///         qitem(Encoding::Deflate),
@@ -49,11 +51,12 @@ header! {
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Te, Encoding, QualityItem, q, qitem};
+    /// # extern crate http;
+    /// use hyperx::header::{Te, Encoding, QualityItem, q, qitem, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Te(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Te(vec![
     ///         qitem(Encoding::Trailers),
     ///         QualityItem::new(Encoding::Gzip, q(600)),
     ///         QualityItem::new(Encoding::EncodingExt("*".to_owned()), q(0)),

--- a/src/header/common/transfer_encoding.rs
+++ b/src/header/common/transfer_encoding.rs
@@ -29,11 +29,12 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, TransferEncoding, Encoding};
+    /// # extern crate http;
+    /// use hyperx::header::{TransferEncoding, Encoding, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     TransferEncoding(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &TransferEncoding(vec![
     ///         Encoding::Gzip,
     ///         Encoding::Chunked,
     ///     ])

--- a/src/header/common/upgrade.rs
+++ b/src/header/common/upgrade.rs
@@ -32,18 +32,20 @@ header! {
     /// # Examples
     ///
     /// ```
-    /// use hyperx::header::{Headers, Upgrade, Protocol, ProtocolName};
+    /// # extern crate http;
+    /// use hyperx::header::{Upgrade, Protocol, ProtocolName, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Upgrade(vec![Protocol::new(ProtocolName::WebSocket, None)]));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Upgrade(vec![Protocol::new(ProtocolName::WebSocket, None)]));
     /// ```
     ///
     /// ```
-    /// use hyperx::header::{Headers, Upgrade, Protocol, ProtocolName};
+    /// # extern crate http;
+    /// use hyperx::header::{Upgrade, Protocol, ProtocolName, TypedHeaders};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Upgrade(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Upgrade(vec![
     ///         Protocol::new(ProtocolName::Http, Some("2.0".to_owned())),
     ///         Protocol::new(ProtocolName::Unregistered("SHTTP".to_owned()),
     ///             Some("1.3".to_owned())),

--- a/src/header/common/user_agent.rs
+++ b/src/header/common/user_agent.rs
@@ -30,10 +30,11 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, UserAgent};
+    /// # extern crate http;
+    /// use hyperx::header::{TypedHeaders, UserAgent};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(UserAgent::new("hyper/0.5.2"));
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&UserAgent::new("hyper/0.5.2"));
     /// ```
     (UserAgent, "User-Agent") => Cow[str]
 

--- a/src/header/common/vary.rs
+++ b/src/header/common/vary.rs
@@ -23,26 +23,28 @@ header! {
     /// # Example
     ///
     /// ```
-    /// use hyperx::header::{Headers, Vary};
+    /// # extern crate http;
+    /// use hyperx::header::{TypedHeaders, Vary};
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(Vary::Any);
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(&Vary::Any);
     /// ```
     ///
     /// # Example
     ///
     /// ```
+    /// # extern crate http;
     /// # extern crate hyperx;
     /// # extern crate unicase;
     /// # fn main() {
     /// // extern crate unicase;
     ///
-    /// use hyperx::header::{Headers, Vary};
+    /// use hyperx::header::{TypedHeaders, Vary};
     /// use unicase::Ascii;
     ///
-    /// let mut headers = Headers::new();
-    /// headers.set(
-    ///     Vary::Items(vec![
+    /// let mut headers = http::HeaderMap::new();
+    /// headers.encode(
+    ///     &Vary::Items(vec![
     ///         Ascii::new("accept-encoding".to_owned()),
     ///         Ascii::new("accept-language".to_owned()),
     ///     ])

--- a/src/header/common/warning.rs
+++ b/src/header/common/warning.rs
@@ -35,11 +35,12 @@ use header::parsing::from_one_raw_str;
 /// # Examples
 ///
 /// ```
-/// use hyperx::header::{Headers, Warning};
+/// # extern crate http;
+/// use hyperx::header::{TypedHeaders, Warning};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Warning{
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Warning {
 ///         code: 299,
 ///         agent: "api.hyper.rs".to_owned(),
 ///         text: "Deprecated".to_owned(),
@@ -49,11 +50,12 @@ use header::parsing::from_one_raw_str;
 /// ```
 ///
 /// ```
-/// use hyperx::header::{Headers, HttpDate, Warning};
+/// # extern crate http;
+/// use hyperx::header::{TypedHeaders, HttpDate, Warning};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Warning{
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Warning {
 ///         code: 299,
 ///         agent: "api.hyper.rs".to_owned(),
 ///         text: "Deprecated".to_owned(),
@@ -63,12 +65,13 @@ use header::parsing::from_one_raw_str;
 /// ```
 ///
 /// ```
+/// # extern crate http;
 /// use std::time::SystemTime;
-/// use hyperx::header::{Headers, Warning};
+/// use hyperx::header::{TypedHeaders, Warning};
 ///
-/// let mut headers = Headers::new();
-/// headers.set(
-///     Warning{
+/// let mut headers = http::HeaderMap::new();
+/// headers.encode(
+///     &Warning {
 ///         code: 199,
 ///         agent: "api.hyper.rs".to_owned(),
 ///         text: "Deprecated".to_owned(),

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -25,7 +25,7 @@ pub trait StandardHeader: Header + Sized {
 }
 
 /// Extension trait for `decode` (parsing) and `encode` (serialization) of
-/// typed headers from/to a collection of headers such as `HeaderMap`.
+/// typed headers from/to a collection of headers such as `http::HeaderMap`.
 pub trait TypedHeaders {
     /// Decode and return `Header` type H or `Error::Header`.
     ///

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -1,4 +1,5 @@
-//! Implementation module for various _compat_ features with the _http_ crate.
+//! Implementation module for various compatibility features with the _http_
+//! crate.
 
 use std::convert::From;
 use std::fmt::Display;

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -226,10 +226,10 @@ mod tests {
     use http;
     use ::header::{
         ContentEncoding, ContentLength, Encoding, ETag,
-        Header, Host, Te, TypedHeaders};
+        Header, Te, TypedHeaders};
 
     #[cfg(feature = "headers")]
-    use ::header::Headers;
+    use ::header::{Headers, Host};
 
     #[cfg(feature = "nightly")]
     use test::Bencher;

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -1,14 +1,24 @@
 //! Implementation module for various compatibility features with the _http_
 //! crate.
 
+#[cfg(feature = "headers")]
 use std::convert::From;
+
 use std::fmt::Display;
 
+#[cfg(feature = "headers")]
 use http;
+
 use http::header::{GetAll, HeaderMap, HeaderValue, ValueIter};
 
 use ::Result;
-use super::{Header, Headers, Raw, RawLike};
+use super::{Header, RawLike};
+
+#[cfg(feature = "headers")]
+use super::Raw;
+
+#[cfg(feature = "headers")]
+use super::Headers;
 
 /// A trait for the "standard" headers that have an associated `HeaderName`
 /// constant in the _http_ crate.
@@ -98,6 +108,7 @@ impl TypedHeaders for HeaderMap {
     }
 }
 
+#[cfg(feature = "headers")]
 impl From<http::HeaderMap> for Headers {
     fn from(mut header_map: http::HeaderMap) -> Headers {
         let mut headers = Headers::new();
@@ -114,6 +125,7 @@ impl From<http::HeaderMap> for Headers {
     }
 }
 
+#[cfg(feature = "headers")]
 impl<'a> From<&'a http::HeaderMap> for Headers {
     fn from(header_map: &'a http::HeaderMap) -> Headers {
         let mut headers = Headers::new();
@@ -124,6 +136,7 @@ impl<'a> From<&'a http::HeaderMap> for Headers {
     }
 }
 
+#[cfg(feature = "headers")]
 impl From<Headers> for http::HeaderMap {
     #[inline]
     fn from(headers: Headers) -> http::HeaderMap {
@@ -131,6 +144,7 @@ impl From<Headers> for http::HeaderMap {
     }
 }
 
+#[cfg(feature = "headers")]
 impl<'a> From<&'a Headers> for http::HeaderMap {
     fn from(headers: &'a Headers) -> http::HeaderMap {
         let mut hmap = http::HeaderMap::new();
@@ -212,7 +226,10 @@ mod tests {
     use http;
     use ::header::{
         ContentEncoding, ContentLength, Encoding, ETag,
-        Header, Headers, Host, Te, TypedHeaders};
+        Header, Host, Te, TypedHeaders};
+
+    #[cfg(feature = "headers")]
+    use ::header::Headers;
 
     #[cfg(feature = "nightly")]
     use test::Bencher;
@@ -310,6 +327,7 @@ mod tests {
             vec![Encoding::Identity, Encoding::Gzip, Encoding::Chunked]);
     }
 
+    #[cfg(feature = "headers")]
     fn raw_headers_sample() -> Headers {
         let mut heads = Headers::new();
 
@@ -333,6 +351,7 @@ mod tests {
         heads
     }
 
+    #[cfg(feature = "headers")]
     #[test]
     fn test_convert_mixed() {
         let mut headers = Headers::new();
@@ -356,6 +375,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "headers")]
     fn test_convert_sample() {
         let headers = raw_headers_sample();
         let hmap = http::HeaderMap::from(headers.clone());
@@ -368,6 +388,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "headers")]
     fn test_convert_by_ref() {
         let headers = raw_headers_sample();
         let hmap = http::HeaderMap::from(&headers);
@@ -527,7 +548,7 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", feature = "headers"))]
     #[bench]
     fn bench_5_map_from_headers(b: &mut Bencher) {
         let heads = raw_headers_sample();
@@ -537,7 +558,7 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", feature = "headers"))]
     #[bench]
     fn bench_5_headers_from_map(b: &mut Bencher) {
         let heads = raw_headers_sample();
@@ -548,7 +569,7 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", feature = "headers"))]
     #[bench]
     fn bench_5_headers_from_map_by_value(b: &mut Bencher) {
         let heads = raw_headers_sample();

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -508,7 +508,7 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "nightly")]
+    #[cfg(all(feature = "nightly", feature = "headers"))]
     #[bench]
     fn bench_3_get_orig_int(b: &mut Bencher) {
         let mut hdrs = ::header::Headers::new();

--- a/src/header/compat.rs
+++ b/src/header/compat.rs
@@ -1,13 +1,7 @@
 //! Implementation module for various compatibility features with the _http_
 //! crate.
 
-#[cfg(feature = "headers")]
-use std::convert::From;
-
 use std::fmt::Display;
-
-#[cfg(feature = "headers")]
-use http;
 
 use http::header::{GetAll, HeaderMap, HeaderValue, ValueIter};
 
@@ -15,10 +9,13 @@ use ::Result;
 use super::{Header, RawLike};
 
 #[cfg(feature = "headers")]
-use super::Raw;
+use std::convert::From;
 
 #[cfg(feature = "headers")]
-use super::Headers;
+use http;
+
+#[cfg(feature = "headers")]
+use super::{Raw, Headers};
 
 /// A trait for the "standard" headers that have an associated `HeaderName`
 /// constant in the _http_ crate.

--- a/src/header/internals/mod.rs
+++ b/src/header/internals/mod.rs
@@ -1,6 +1,16 @@
-pub use self::item::Item;
-pub use self::vec_map::{VecMap, Entry};
 
+#[cfg(feature = "headers")]
+pub use self::item::Item;
+
+pub use self::vec_map::VecMap;
+
+#[cfg(feature = "headers")]
+pub use self::vec_map::Entry;
+
+#[cfg(feature = "headers")]
 mod cell;
+
+#[cfg(feature = "headers")]
 mod item;
+
 mod vec_map;

--- a/src/header/internals/vec_map.rs
+++ b/src/header/internals/vec_map.rs
@@ -28,6 +28,7 @@ impl<K: PartialEq, V> VecMap<K, V> {
         self.vec.push((key, value));
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     pub fn entry(&mut self, key: K) -> Entry<K, V> {
         match self.pos(&key) {
@@ -47,11 +48,13 @@ impl<K: PartialEq, V> VecMap<K, V> {
         self.find(key).map(|entry| &entry.1)
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     pub fn get_mut<K2: PartialEq<K> + ?Sized>(&mut self, key: &K2) -> Option<&mut V> {
         self.find_mut(key).map(|entry| &mut entry.1)
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     pub fn contains_key<K2: PartialEq<K> + ?Sized>(&self, key: &K2) -> bool {
         self.find(key).is_some()
@@ -65,6 +68,7 @@ impl<K: PartialEq, V> VecMap<K, V> {
         self.vec.iter()
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     pub fn remove<K2: PartialEq<K> + ?Sized>(&mut self, key: &K2) -> Option<V> {
         self.pos(key).map(|pos| self.vec.remove(pos)).map(|(_, v)| v)
@@ -80,6 +84,7 @@ impl<K: PartialEq, V> VecMap<K, V> {
         }
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     pub fn clear(&mut self) {
         self.vec.clear();
@@ -95,6 +100,7 @@ impl<K: PartialEq, V> VecMap<K, V> {
         None
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     fn find_mut<K2: PartialEq<K> + ?Sized>(&mut self, key: &K2) -> Option<&mut (K, V)> {
         for entry in &mut self.vec {
@@ -105,22 +111,26 @@ impl<K: PartialEq, V> VecMap<K, V> {
         None
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     fn pos<K2: PartialEq<K> + ?Sized>(&self, key: &K2) -> Option<usize> {
         self.vec.iter().position(|entry| key == &entry.0)
     }
 }
 
+#[cfg(feature = "headers")]
 pub enum Entry<'a, K: 'a, V: 'a> {
     Vacant(VacantEntry<'a, K, V>),
     Occupied(OccupiedEntry<'a, K, V>)
 }
 
+#[cfg(feature = "headers")]
 pub struct VacantEntry<'a, K: 'a, V: 'a> {
     vec: &'a mut Vec<(K, V)>,
     key: K,
 }
 
+#[cfg(feature = "headers")]
 impl<'a, K, V> VacantEntry<'a, K, V> {
     pub fn insert(self, val: V) -> &'a mut V {
         self.vec.push((self.key, val));
@@ -129,11 +139,13 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     }
 }
 
+#[cfg(feature = "headers")]
 pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
     vec: &'a mut Vec<(K, V)>,
     pos: usize,
 }
 
+#[cfg(feature = "headers")]
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub fn into_mut(self) -> &'a mut V {
         &mut self.vec[self.pos].1

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -404,7 +404,12 @@ fn header_name<T: Header>() -> &'static str {
     <T as Header>::header_name()
 }
 
-/// A map of header fields on requests and responses.
+/// A specialized map of typed headers.
+///
+/// This type is only available with the non-default _headers_ feature
+/// enabled. The type is preserved for compatibly, but its use is no longer
+/// required nor recommended. Consider replacing with `http::HeaderMap` and its
+/// [`TypedHeaders`](trait.TypedHeaders.html) extension.
 #[cfg(feature = "headers")]
 #[derive(Clone)]
 pub struct Headers {

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -243,12 +243,10 @@ mod sealed {
 #[allow(missing_debug_implementations)]
 pub struct Formatter<'a, 'b: 'a>(Multi<'a, 'b>);
 
+#[allow(unused)]
 enum Multi<'a, 'b: 'a> {
-    #[allow(unused)]
     Line(&'a str, &'a mut fmt::Formatter<'b>),
-    #[allow(unused)]
     Join(bool, &'a mut fmt::Formatter<'b>),
-    #[allow(unused)]
     Raw(&'a mut Raw),
 }
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -813,18 +813,17 @@ impl PartialEq<HeaderName> for str {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "headers"))]
 mod tests {
     use std::fmt;
-    use super::{Header, RawLike};
 
-    #[cfg(feature = "headers")]
-    use super::{Headers, ContentLength, ContentType, Host, SetCookie};
+    use super::{
+        Header, Headers, ContentLength, ContentType, Host, RawLike, SetCookie
+    };
 
     #[cfg(feature = "nightly")]
     use test::Bencher;
 
-    #[cfg(feature = "headers")]
     macro_rules! make_header {
         ($name:expr, $value:expr) => ({
             let mut headers = Headers::new();
@@ -838,7 +837,6 @@ mod tests {
         })
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_from_raw() {
         let headers = make_header!(b"Content-Length", b"10");
@@ -878,7 +876,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_different_structs_for_same_header() {
         let headers = make_header!(b"Content-Length: 10");
@@ -886,14 +883,12 @@ mod tests {
         assert_eq!(headers.get::<CrazyLength>(), Some(&CrazyLength(Some(false), 10)));
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_trailing_whitespace() {
         let headers = make_header!(b"Content-Length: 10   ");
         assert_eq!(headers.get::<ContentLength>(), Some(&ContentLength(10)));
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_multiple_reads() {
         let headers = make_header!(b"Content-Length: 10");
@@ -902,7 +897,6 @@ mod tests {
         assert_eq!(one, two);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_different_reads() {
         let mut headers = Headers::new();
@@ -912,7 +906,6 @@ mod tests {
         let ContentType(_) = *headers.get::<ContentType>().unwrap();
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_typed_get_raw() {
         let mut headers = Headers::new();
@@ -926,7 +919,6 @@ mod tests {
         assert_eq!(headers.get_raw("set-cookie").unwrap(), &["foo=bar", "baz=quux; Path=/path"][..]);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_get_mutable() {
         let mut headers = make_header!(b"Content-Length: 10");
@@ -935,7 +927,6 @@ mod tests {
         assert_eq!(*headers.get::<ContentLength>().unwrap(), ContentLength(20));
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_headers_to_string() {
         let mut headers = Headers::new();
@@ -947,7 +938,6 @@ mod tests {
         assert!(s.contains("Content-Length: 15\r\n"));
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_headers_to_string_raw() {
         let mut headers = make_header!(b"Content-Length: 10");
@@ -956,7 +946,6 @@ mod tests {
         assert_eq!(s, "Content-Length: 10\r\nx-foo: foo\r\nx-foo: bar\r\n");
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_set_raw() {
         let mut headers = Headers::new();
@@ -966,7 +955,6 @@ mod tests {
         assert_eq!(headers.get(), Some(&ContentLength(20)));
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_append_raw() {
         let mut headers = Headers::new();
@@ -977,7 +965,6 @@ mod tests {
         assert_eq!(headers.get_raw("x-foo").unwrap(), &[b"bar".to_vec()][..]);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_remove_raw() {
         let mut headers = Headers::new();
@@ -986,7 +973,6 @@ mod tests {
         assert_eq!(headers.get_raw("Content-length"), None);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_remove() {
         let mut headers = Headers::new();
@@ -1000,7 +986,6 @@ mod tests {
         assert_eq!(headers.len(), 0);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_len() {
         let mut headers = Headers::new();
@@ -1013,7 +998,6 @@ mod tests {
         assert_eq!(headers.len(), 2);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_clear() {
         let mut headers = Headers::new();
@@ -1024,7 +1008,6 @@ mod tests {
         assert_eq!(headers.len(), 0);
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_iter() {
         let mut headers = Headers::new();
@@ -1037,7 +1020,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_header_view_value_string() {
         let mut headers = Headers::new();
@@ -1048,7 +1030,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_header_view_raw() {
         let mut headers = Headers::new();
@@ -1060,7 +1041,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "headers")]
     #[test]
     fn test_eq() {
         let mut headers1 = Headers::new();
@@ -1091,7 +1071,7 @@ mod tests {
         assert_ne!(headers1, headers2);
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_new(b: &mut Bencher) {
         b.iter(|| {
@@ -1101,7 +1081,7 @@ mod tests {
         })
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_get(b: &mut Bencher) {
         let mut headers = Headers::new();
@@ -1109,14 +1089,14 @@ mod tests {
         b.iter(|| assert_eq!(headers.get::<ContentLength>(), Some(&ContentLength(11))))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_get_miss(b: &mut Bencher) {
         let headers = Headers::new();
         b.iter(|| assert!(headers.get::<ContentLength>().is_none()))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_get_miss_previous_10(b: &mut Bencher) {
         let mut headers = Headers::new();
@@ -1126,14 +1106,14 @@ mod tests {
         b.iter(|| assert!(headers.get::<ContentLength>().is_none()))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_set(b: &mut Bencher) {
         let mut headers = Headers::new();
         b.iter(|| headers.set(ContentLength(12)))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_set_previous_10(b: &mut Bencher) {
         let mut headers = Headers::new();
@@ -1143,14 +1123,14 @@ mod tests {
         b.iter(|| headers.set(ContentLength(12)))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_set_raw(b: &mut Bencher) {
         let mut headers = Headers::new();
         b.iter(|| headers.set_raw("non-standard", "hello"))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_set_raw_previous_10(b: &mut Bencher) {
         let mut headers = Headers::new();
@@ -1160,7 +1140,7 @@ mod tests {
         b.iter(|| headers.set_raw("non-standard", "hello"))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_has(b: &mut Bencher) {
         let mut headers = Headers::new();
@@ -1168,7 +1148,7 @@ mod tests {
         b.iter(|| assert!(headers.has::<ContentLength>()))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_view_is(b: &mut Bencher) {
         let mut headers = Headers::new();
@@ -1178,7 +1158,7 @@ mod tests {
         b.iter(|| assert!(view.is::<ContentLength>()))
     }
 
-    #[cfg(all(feature = "nightly", feature = "headers"))]
+    #[cfg(feature = "nightly")]
     #[bench]
     fn bench_headers_fmt(b: &mut Bencher) {
         use std::fmt::Write;

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -249,8 +249,11 @@ mod sealed {
 pub struct Formatter<'a, 'b: 'a>(Multi<'a, 'b>);
 
 enum Multi<'a, 'b: 'a> {
+    #[allow(unused)]
     Line(&'a str, &'a mut fmt::Formatter<'b>),
+    #[allow(unused)]
     Join(bool, &'a mut fmt::Formatter<'b>),
+    #[allow(unused)]
     Raw(&'a mut Raw),
 }
 

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -21,16 +21,13 @@
 //!
 //! ## Parsing `http::header::HeaderValue`s
 //!
-//! With the default *compat* feature enabled, `HeaderValue`(s) implement the
-//! `RawLike` trait which allows for parsing with less copying than going
-//! through `HeaderValue::to_str` or the `Raw` type. See example usage below:
+//! `HeaderValue`(s) implement the `RawLike` trait which allows for parsing
+//! with less copying than going through `HeaderValue::to_str` or the `Raw`
+//! type. See example usage below:
 //!
 //! ```
-//! # #[cfg(feature = "compat")]
 //! # extern crate hyperx;
-//! # #[cfg(feature = "compat")]
 //! # extern crate http;
-//! # #[cfg(feature = "compat")]
 //! # fn run() -> Result<(), Box<std::error::Error>> {
 //! use http::header::{HeaderMap, CONTENT_ENCODING};
 //! use hyperx::header::{ContentEncoding, Encoding, Header};
@@ -53,12 +50,8 @@
 //! ));
 //! # Ok(())
 //! # }
-//! # #[cfg(feature = "compat")]
 //! # fn main() {
 //! #     run().unwrap();
-//! # }
-//! # #[cfg(not(feature = "compat"))]
-//! # fn main() {
 //! # }
 //! ```
 //!
@@ -69,11 +62,8 @@
 //! standard header types named in the _http_ crate:
 //!
 //! ```
-//! # #[cfg(feature = "compat")]
 //! # extern crate hyperx;
-//! # #[cfg(feature = "compat")]
 //! # extern crate http;
-//! # #[cfg(feature = "compat")]
 //! # fn run() -> Result<(), Box<std::error::Error>> {
 //! use http::header::HeaderMap;
 //! use hyperx::header::{ContentEncoding, Encoding, TypedHeaders};
@@ -90,12 +80,8 @@
 //! );
 //! # Ok(())
 //! # }
-//! # #[cfg(feature = "compat")]
 //! # fn main() {
 //! #     run().unwrap();
-//! # }
-//! # #[cfg(not(feature = "compat"))]
-//! # fn main() {
 //! # }
 //! ```
 //!
@@ -185,10 +171,8 @@ mod raw;
 mod shared;
 pub mod parsing;
 
-#[cfg(feature = "compat")]
 mod compat;
 
-#[cfg(feature = "compat")]
 pub use self::compat::{TypedHeaders, StandardHeader, ValueMapIter};
 
 /// A trait for any object that will represent a header field and value.

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -87,20 +87,23 @@
 //!
 //! ## Defining Custom Headers
 //!
-//! Hyper*x* provides many of the most commonly used headers in HTTP. If you
+//! Hyper*x* provides all commonly used headers in HTTP. If you
 //! need to define a custom header, it's easy to do while still taking
 //! advantage of the type system. Hyper*x* includes a `header!` macro for
 //! defining many wrapper-style headers.
 //!
 //! ```
+//! # extern crate http;
 //! # #[macro_use] extern crate hyperx;
-//! use hyperx::header::Headers;
 //! header! { (XRequestGuid, "X-Request-Guid") => [String] }
 //!
 //! fn main () {
-//!     let mut headers = Headers::new();
+//!     let mut headers = http::HeaderMap::new();
 //!
-//!     headers.set(XRequestGuid("a proper guid".to_owned()))
+//!     headers.insert(
+//!         "x-request-guid",
+//!         XRequestGuid("a proper guid".to_owned()).to_string().parse().unwrap()
+//!     );
 //! }
 //! ```
 //!
@@ -125,7 +128,7 @@
 //!     }
 //!
 //!     fn parse_header<'a, T>(raw: &'a T) -> hyperx::Result<Dnt>
-//!     where T: RawLike<'a>
+//!         where T: RawLike<'a>
 //!     {
 //!         if let Some(line) = raw.one() {
 //!             if line.len() == 1 {

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -151,25 +151,9 @@
 //! }
 //! ```
 use std::borrow::Cow;
-
-#[cfg(feature = "headers")]
-use std::borrow::ToOwned;
-
-#[cfg(feature = "headers")]
-use std::iter::{FromIterator, IntoIterator};
-
 use std::fmt;
 
-#[cfg(feature = "headers")]
-use std::mem;
-
 use unicase::Ascii;
-
-#[cfg(feature = "headers")]
-use self::internals::{Item};
-
-#[cfg(feature = "headers")]
-use self::internals::{VecMap, Entry};
 
 use self::sealed::HeaderClone;
 
@@ -178,18 +162,26 @@ pub use self::common::*;
 pub use self::raw::{Raw, RawLike};
 
 #[cfg(feature = "headers")]
+use std::{
+    borrow::ToOwned,
+    iter::{FromIterator, IntoIterator},
+    mem,
+};
+
+#[cfg(feature = "headers")]
+use self::internals::{Item, VecMap, Entry};
+
+#[cfg(feature = "headers")]
 use bytes::Bytes;
 
-mod common;
+pub use self::compat::{TypedHeaders, StandardHeader, ValueMapIter};
 
+mod common;
 mod internals;
 mod raw;
 mod shared;
 pub mod parsing;
-
 mod compat;
-
-pub use self::compat::{TypedHeaders, StandardHeader, ValueMapIter};
 
 /// A trait for any object that will represent a header field and value.
 ///

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -150,15 +150,22 @@
 //!     }
 //! }
 //! ```
-use std::borrow::{Cow, ToOwned};
+use std::borrow::Cow;
+
+#[cfg(feature = "headers")]
+use std::borrow::ToOwned;
 
 #[cfg(feature = "headers")]
 use std::iter::{FromIterator, IntoIterator};
 
-use std::{mem, fmt};
+use std::fmt;
+
+#[cfg(feature = "headers")]
+use std::mem;
 
 use unicase::Ascii;
 
+#[cfg(feature = "headers")]
 use self::internals::{Item};
 
 #[cfg(feature = "headers")]
@@ -174,6 +181,7 @@ pub use self::raw::{Raw, RawLike};
 use bytes::Bytes;
 
 mod common;
+
 mod internals;
 mod raw;
 mod shared;
@@ -312,8 +320,10 @@ impl<'a, 'b> Formatter<'a, 'b> {
     }
 }
 
+#[cfg(feature = "headers")]
 struct ValueString<'a>(&'a Item);
 
+#[cfg(feature = "headers")]
 impl<'a> fmt::Debug for ValueString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str("\"")?;
@@ -322,6 +332,7 @@ impl<'a> fmt::Debug for ValueString<'a> {
     }
 }
 
+#[cfg(feature = "headers")]
 impl<'a> fmt::Display for ValueString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.write_h1(&mut Formatter(Multi::Join(true, f)))
@@ -363,16 +374,19 @@ impl dyn Header + Send + Sync {
     // order the compiler has chosen to represent a TraitObject.
     //
     // It has been assured that this order will be stable.
+    #[cfg(feature = "headers")]
     #[inline]
     unsafe fn downcast_ref_unchecked<T: 'static>(&self) -> &T {
         &*(mem::transmute::<*const _, (*const (), *const ())>(self).0 as *const T)
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     unsafe fn downcast_mut_unchecked<T: 'static>(&mut self) -> &mut T {
         &mut *(mem::transmute::<*mut _, (*mut (), *mut ())>(self).0 as *mut T)
     }
 
+    #[cfg(feature = "headers")]
     #[inline]
     unsafe fn downcast_unchecked<T: 'static>(self: Box<Self>) -> T {
         *Box::from_raw(mem::transmute::<*mut _, (*mut (), *mut ())>(Box::into_raw(self)).0 as *mut T)
@@ -386,6 +400,7 @@ impl Clone for Box<dyn Header + Send + Sync> {
     }
 }
 
+#[cfg(feature = "headers")]
 #[inline]
 fn header_name<T: Header>() -> &'static str {
     <T as Header>::header_name()
@@ -407,6 +422,7 @@ impl Default for Headers {
 
 macro_rules! literals {
     ($($len:expr => $($header:path),+;)+) => (
+        #[cfg(feature = "headers")]
         fn maybe_literal(s: &str) -> Cow<'static, str> {
             match s.len() {
                 $($len => {
@@ -652,11 +668,13 @@ impl fmt::Debug for Headers {
 }
 
 /// An `Iterator` over the fields in a `Headers` map.
+#[cfg(feature = "headers")]
 #[allow(missing_debug_implementations)]
 pub struct HeadersItems<'a> {
     inner: ::std::slice::Iter<'a, (HeaderName, Item)>
 }
 
+#[cfg(feature = "headers")]
 impl<'a> Iterator for HeadersItems<'a> {
     type Item = HeaderView<'a>;
 
@@ -666,8 +684,10 @@ impl<'a> Iterator for HeadersItems<'a> {
 }
 
 /// Returned with the `HeadersItems` iterator.
+#[cfg(feature = "headers")]
 pub struct HeaderView<'a>(&'a HeaderName, &'a Item);
 
+#[cfg(feature = "headers")]
 impl<'a> HeaderView<'a> {
     /// Check if a HeaderView is a certain Header.
     #[inline]
@@ -705,6 +725,7 @@ impl<'a> HeaderView<'a> {
     }
 }
 
+#[cfg(feature = "headers")]
 impl<'a> fmt::Display for HeaderView<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -712,6 +733,7 @@ impl<'a> fmt::Display for HeaderView<'a> {
     }
 }
 
+#[cfg(feature = "headers")]
 impl<'a> fmt::Debug for HeaderView<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -799,12 +821,10 @@ impl PartialEq<HeaderName> for str {
 #[cfg(test)]
 mod tests {
     use std::fmt;
-    use super::{
-        Header, RawLike, ContentLength, ContentType, Host,
-        SetCookie};
+    use super::{Header, RawLike};
 
     #[cfg(feature = "headers")]
-    use super::Headers;
+    use super::{Headers, ContentLength, ContentType, Host, SetCookie};
 
     #[cfg(feature = "nightly")]
     use test::Bencher;

--- a/src/header/raw.rs
+++ b/src/header/raw.rs
@@ -209,14 +209,17 @@ impl From<Bytes> for Raw {
     }
 }
 
+#[cfg(feature = "headers")]
 pub fn parsed(val: Bytes) -> Raw {
     Raw(Lines::One(From::from(val)))
 }
 
+#[cfg(feature = "headers")]
 pub fn push(raw: &mut Raw, val: Bytes) {
     raw.push_line(val);
 }
 
+#[cfg(feature = "headers")]
 pub fn new() -> Raw {
     Raw(Lines::Empty)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 
 extern crate base64;
 extern crate bytes;
-#[cfg(feature = "compat")]
 extern crate http;
 extern crate httparse;
 extern crate language_tags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,10 @@ extern crate unicase;
 extern crate test;
 
 pub use error::{Result, Error};
+
+#[cfg(feature = "headers")]
 pub use header::Headers;
+
 pub use method::Method;
 
 mod error;

--- a/src/method.rs
+++ b/src/method.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use std::str::FromStr;
 use std::convert::AsRef;
 
-#[cfg(feature = "compat")]
 use http;
 
 use error::Error;
@@ -158,7 +157,6 @@ impl Default for Method {
     }
 }
 
-#[cfg(feature = "compat")]
 impl From<http::Method> for Method {
     fn from(method: http::Method) -> Method {
         match method {
@@ -188,7 +186,6 @@ impl From<http::Method> for Method {
     }
 }
 
-#[cfg(feature = "compat")]
 impl From<Method> for http::Method {
     fn from(method: Method) -> http::Method {
         use http::HttpTryFrom;
@@ -276,7 +273,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "compat")]
     fn test_compat() {
         use http::{self, HttpTryFrom};
 


### PR DESCRIPTION
PR'ing for visibility and any comment.  The changes here are best summarized by the change log additions:

> * The default _compat_ feature is no longer optional, as its unlikely that anyone would be using recent versions without this feature. The feature gate name is retained for now, but has no effect.
> 
> * Place the legacy `Headers` struct under a new non-default _headers_ feature  gate. Note that use of this type is no longer required nor recommended for parsing and serialization of typed headers. See the rewritten typed header doc examples.  Consider replacing with the _http_ crate `HeaderMap` and the `TypedHeaders` extension trait introduced here in 0.15.0.
> 

The motivation for this is to steer new users in the best direction (using `http::HeaderMap` instead of `Headers` when possible), avoiding such issues as #17, and a minor compile time and size improvement when the _headers_ feature is not enabled.


