### PR TITLE
Use httpdate::HttpDate as our inner date type (replace time)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
 name = "hyperx"
 version = "1.1.0"
 dependencies = [
@@ -49,11 +55,11 @@ dependencies = [
  "bytes",
  "http",
  "httparse",
+ "httpdate",
  "language-tags",
  "log",
  "mime",
  "percent-encoding",
- "time",
  "unicase",
 ]
 
@@ -68,12 +74,6 @@ name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
-name = "libc"
-version = "0.2.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755456fae044e6fa1ebbbd1b3e902ae19e73097ed4ed87bb79934a867c007bc3"
 
 [[package]]
 name = "log"
@@ -97,16 +97,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,25 +110,3 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ build = "build.rs"
 base64              = { version=">=0.10.1, <0.13" }
 bytes               = { version=">=0.5.2, <0.6" }
 http                = { version=">=0.2.0, <0.3" }
-httpdate            = "0.3.2"
+httpdate            = { version=">=0.3.2, <0.4" }
 httparse            = { version=">=1.0, <1.4" }
 language-tags       = { version=">=0.2, <0.3" }
 log                 = { version=">=0.4, <0.5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ build = "build.rs"
 base64              = { version=">=0.10.1, <0.13" }
 bytes               = { version=">=0.5.2, <0.6" }
 http                = { version=">=0.2.0, <0.3" }
+httpdate            = "0.3.2"
 httparse            = { version=">=1.0, <1.4" }
 language-tags       = { version=">=0.2, <0.3" }
 log                 = { version=">=0.4, <0.5" }
 mime                = { version=">=0.3.2, <0.4" }
 percent-encoding    = { version=">=2.1.0, <2.2" }
-time                = { version=">=0.1.39, <0.2" }
 unicase             = { version=">=2.6.0, <2.7" }
 
 [features]

--- a/src/header/shared/httpdate.rs
+++ b/src/header/shared/httpdate.rs
@@ -1,8 +1,8 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
-use time;
+use httpdate;
 
 /// A timestamp with HTTP formatting and parsing
 //   Prior to 1995, there were three different formats commonly used by
@@ -28,87 +28,55 @@ use time;
 //   HTTP-date, the sender MUST generate those timestamps in the
 //   IMF-fixdate format.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct HttpDate(time::Tm);
+pub struct HttpDate(SystemTime);
 
 impl FromStr for HttpDate {
     type Err = ::Error;
     fn from_str(s: &str) -> ::Result<HttpDate> {
-        match time::strptime(s, "%a, %d %b %Y %T %Z").or_else(|_| {
-            time::strptime(s, "%A, %d-%b-%y %T %Z")
-            }).or_else(|_| {
-                time::strptime(s, "%c")
-                }) {
-                    Ok(t) => Ok(HttpDate(t)),
-                    Err(_) => Err(::Error::Header),
-                    }
+        httpdate::parse_http_date(s)
+            .map(|date| HttpDate::from(date))
+            .map_err(|_| ::Error::Header)
     }
 }
 
 impl Display for HttpDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.0.to_utc().rfc822(), f)
+        fmt::Display::fmt(&httpdate::fmt_http_date(self.0), f)
     }
 }
 
 impl From<SystemTime> for HttpDate {
     fn from(sys: SystemTime) -> HttpDate {
-        let tmspec = match sys.duration_since(UNIX_EPOCH) {
-            Ok(dur) => {
-                time::Timespec::new(dur.as_secs() as i64, dur.subsec_nanos() as i32)
-            },
-            Err(err) => {
-                let neg = err.duration();
-                time::Timespec::new(-(neg.as_secs() as i64), -(neg.subsec_nanos() as i32))
-            },
-        };
-        HttpDate(time::at_utc(tmspec))
+        HttpDate(sys)
     }
 }
 
 impl From<HttpDate> for SystemTime {
     fn from(date: HttpDate) -> SystemTime {
-        let spec = date.0.to_timespec();
-        if spec.sec >= 0 {
-            UNIX_EPOCH + Duration::new(spec.sec as u64, spec.nsec as u32)
-        } else {
-            UNIX_EPOCH - Duration::new(spec.sec as u64, spec.nsec as u32)
-        }
+        date.0
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use time::Tm;
+    use std::time::{SystemTime, Duration};
+
     use super::HttpDate;
 
-    const NOV_07: HttpDate = HttpDate(Tm {
-        tm_nsec: 0,
-        tm_sec: 37,
-        tm_min: 48,
-        tm_hour: 8,
-        tm_mday: 7,
-        tm_mon: 10,
-        tm_year: 94,
-        tm_wday: 0,
-        tm_isdst: 0,
-        tm_yday: 0,
-        tm_utcoff: 0,
-    });
+    macro_rules! test_parse {
+        ($function: ident, $date: expr) => {
+            #[test]
+            fn $function() {
+                let nov_07 = HttpDate(SystemTime::UNIX_EPOCH + Duration::new(784198117, 0));
 
-    #[test]
-    fn test_imf_fixdate() {
-        assert_eq!("Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>().unwrap(), NOV_07);
+                assert_eq!($date.parse::<HttpDate>().unwrap(), nov_07);
+            }
+        };
     }
 
-    #[test]
-    fn test_rfc_850() {
-        assert_eq!("Sunday, 07-Nov-94 08:48:37 GMT".parse::<HttpDate>().unwrap(), NOV_07);
-    }
-
-    #[test]
-    fn test_asctime() {
-        assert_eq!("Sun Nov  7 08:48:37 1994".parse::<HttpDate>().unwrap(), NOV_07);
-    }
+    test_parse!(test_imf_fixdate, "Sun, 07 Nov 1994 08:48:37 GMT");
+    test_parse!(test_rfc_850, "Sunday, 07-Nov-94 08:48:37 GMT");
+    test_parse!(test_asctime, "Sun Nov  7 08:48:37 1994");
 
     #[test]
     fn test_no_date() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate language_tags;
 #[macro_use] extern crate log;
 pub extern crate mime;
 extern crate percent_encoding;
-extern crate time;
+extern crate httpdate;
 extern crate unicase;
 
 #[cfg(all(test, feature = "nightly"))]


### PR DESCRIPTION
Extends #22 (fixes #21). Since `httpdate::parse_http_date` and `fmt_http_date` are implemented in terms of the `httpdate::HttpDate` type, I figured this was worth a try.  The existing benchmarks (e.g. round trip for Date header) are improved with this variant over #22 (which itself is an improvement over master).