### PR TITLE
remove very limited use of `log` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,12 +13,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,7 +51,6 @@ dependencies = [
  "httparse",
  "httpdate",
  "language-tags",
- "log",
  "mime",
  "percent-encoding",
  "unicase",
@@ -74,15 +67,6 @@ name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-
-[[package]]
-name = "log"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ http                = { version=">=0.2.0, <0.3" }
 httpdate            = { version=">=0.3.2, <0.4" }
 httparse            = { version=">=1.0, <1.4" }
 language-tags       = { version=">=0.2, <0.3" }
-log                 = { version=">=0.4, <0.5" }
 mime                = { version=">=0.3.2, <0.4" }
 percent-encoding    = { version=">=2.1.0, <2.2" }
 unicase             = { version=">=2.6.0, <2.7" }

--- a/src/header/common/authorization.rs
+++ b/src/header/common/authorization.rs
@@ -193,12 +193,10 @@ impl FromStr for Basic {
                     })
                 },
                 Err(_) => {
-                    debug!("Basic::from_str utf8 error");
                     Err(::Error::Header)
                 }
             },
             Err(_) => {
-                debug!("Basic::from_str base64 error");
                 Err(::Error::Header)
             }
         }

--- a/src/header/internals/item.rs
+++ b/src/header/internals/item.rs
@@ -93,7 +93,6 @@ impl Item {
                             f.fmt_line(&s)?;
                         },
                         Err(_) => {
-                            error!("raw header value is not utf8, value={:?}", part);
                             return Err(fmt::Error);
                         }
                     }

--- a/src/header/mod.rs
+++ b/src/header/mod.rs
@@ -437,7 +437,6 @@ macro_rules! literals {
                 _ => ()
             }
 
-            trace!("maybe_literal not found, copying {:?}", s);
             Cow::Owned(s.to_owned())
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate bytes;
 extern crate http;
 extern crate httparse;
 extern crate language_tags;
-#[macro_use] extern crate log;
 pub extern crate mime;
 extern crate percent_encoding;
 extern crate httpdate;


### PR DESCRIPTION
Its seems that the `log` crate dependency is only used as a workaround for unspecific `Error::Header` and other error branches in a few places.  This doesn't seem to be worth the weight as dependencies, particularly those with dubious MSRV update/release policies.