### PR TITLE
Upgrade to bytes 1.0.z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.3.0 (unreleased)
 
+* Broaden _bytes_ dependency to include 1.0.z releases. This is intended to
+  ease transition to bytes 1.0.z across the ecosystem, allowing users to avoid
+  duplicates. The 1.3.z series of _hyperx_ will straddle both versions.
+  (with paolobarbolini #26 #31)
+
 ## 1.2.0 (2020-10-6)
 
 * Replace use of time crate with httpdate crate for date/time typed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,11 +32,11 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -52,7 +58,7 @@ name = "hyperx"
 version = "1.3.0"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 1.0.0",
  "http",
  "httparse",
  "httpdate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ build = "build.rs"
 
 [dependencies]
 base64              = { version=">=0.10.1, <0.14" }
-bytes               = { version=">=0.5.2, <0.6" }
+bytes               = { version=">=0.5.2, <1.1.0" }
 http                = { version=">=0.2.0, <0.3" }
 httpdate            = { version=">=0.3.2, <0.4" }
 httparse            = { version=">=1.0, <1.4" }


### PR DESCRIPTION
Note as is, this would cause a duplicate, which we would prefer to avoid:

```
bytes v0.5.6
└── http v0.2.1
    └── hyperx v1.3.0 (/home/david/src/hyperx)

bytes v0.6.0
└── hyperx v1.3.0 (/home/david/src/hyperx)
```

So for a complete solution this depends on hyperium/http#440