### PR TITLE
Bump bytes crate to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f8e949d755f9d79112b5bb46938e0ef9d3804a0b16dfab13aafcaa5f0fa72"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,11 +32,11 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -52,7 +58,7 @@ name = "hyperx"
 version = "1.3.0"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 1.0.0",
  "http",
  "httparse",
  "httpdate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ build = "build.rs"
 
 [dependencies]
 base64              = { version=">=0.10.1, <0.14" }
-bytes               = { version=">=0.5.2, <0.6" }
+bytes               = { version=">=1.0.0, <2.0" }
 http                = { version=">=0.2.0, <0.3" }
 httpdate            = { version=">=0.3.2, <0.4" }
 httparse            = { version=">=1.0, <1.4" }


### PR DESCRIPTION
A new version of `http`, removing the duplicate dependency version on `bytes`, will be released shortly https://github.com/hyperium/http/pull/457