### PR TITLE
Remove httparse dependency, error conversions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "httparse"
-version = "1.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-
-[[package]]
 name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,7 +42,6 @@ dependencies = [
  "base64",
  "bytes",
  "http",
- "httparse",
  "httpdate",
  "language-tags",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ base64              = { version=">=0.10.1, <0.14" }
 bytes               = { version=">=1.0.0, <1.1.0" }
 http                = { version=">=0.2.2, <0.3" }
 httpdate            = { version=">=0.3.2, <0.4" }
-httparse            = { version=">=1.0, <1.4" }
 language-tags       = { version=">=0.2, <0.3" }
 mime                = { version=">=0.3.2, <0.4" }
 percent-encoding    = { version=">=2.1.0, <2.2" }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,6 @@ use std::fmt;
 use std::str::Utf8Error;
 use std::string::FromUtf8Error;
 
-use httparse;
-
 use self::Error::{
     Method,
     Version,
@@ -97,54 +95,7 @@ impl From<FromUtf8Error> for Error {
     }
 }
 
-impl From<httparse::Error> for Error {
-    fn from(err: httparse::Error) -> Error {
-        match err {
-            httparse::Error::HeaderName |
-            httparse::Error::HeaderValue |
-            httparse::Error::NewLine |
-            httparse::Error::Token => Header,
-            httparse::Error::Status => Status,
-            httparse::Error::TooManyHeaders => TooLarge,
-            httparse::Error::Version => Version,
-        }
-    }
-}
-
 #[doc(hidden)]
 trait AssertSendSync: Send + Sync + 'static {}
 #[doc(hidden)]
 impl AssertSendSync for Error {}
-
-#[cfg(test)]
-mod tests {
-    use httparse;
-    use super::Error;
-    use super::Error::*;
-
-    macro_rules! from {
-        ($from:expr => $error:pat) => {
-            match Error::from($from) {
-                e @ $error => {
-                    assert!(format!("{}", e).len() >= 5);
-                    assert_ne!(
-                        format!("{}", e),
-                        "description() is deprecated; use Display");
-                } ,
-                e => panic!("{:?}", e)
-            }
-        }
-    }
-
-    #[test]
-    fn test_from() {
-        from!(httparse::Error::HeaderName => Header);
-        from!(httparse::Error::HeaderName => Header);
-        from!(httparse::Error::HeaderValue => Header);
-        from!(httparse::Error::NewLine => Header);
-        from!(httparse::Error::Status => Status);
-        from!(httparse::Error::Token => Header);
-        from!(httparse::Error::TooManyHeaders => TooLarge);
-        from!(httparse::Error::Version => Version);
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@
 extern crate base64;
 extern crate bytes;
 extern crate http;
-extern crate httparse;
 extern crate language_tags;
 pub extern crate mime;
 extern crate percent_encoding;


### PR DESCRIPTION
This might be a breaking change, in the unlikely event that something depends on these error conversions. 

It would be safer to include this in a minor release.

