### PR TITLE
Upgrade to language-tags 0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,9 +64,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "language-tags"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
+checksum = "f11dc871dd28acc3ac816c5bbe2c5c7e60c4a41f82ce79699a0a44a8fdbc2c7c"
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytes               = { version=">=1.0.0, <1.1.0" }
 http                = { version=">=0.2.2, <0.3" }
 httpdate            = { version=">=0.3.2, <0.4" }
 httparse            = { version=">=1.0, <1.4" }
-language-tags       = { version=">=0.2, <0.3" }
+language-tags       = { version=">=0.3.1, <0.4" }
 mime                = { version=">=0.3.2, <0.4" }
 percent-encoding    = { version=">=2.1.0, <2.2" }
 unicase             = { version=">=2.6.0, <2.7" }

--- a/src/header/common/accept_language.rs
+++ b/src/header/common/accept_language.rs
@@ -27,9 +27,7 @@ header! {
     /// use hyperx::header::{AcceptLanguage, LanguageTag, qitem, TypedHeaders};
     ///
     /// let mut headers = http::HeaderMap::new();
-    /// let mut langtag: LanguageTag = Default::default();
-    /// langtag.language = Some("en".to_owned());
-    /// langtag.region = Some("US".to_owned());
+    /// let mut langtag: LanguageTag = LanguageTag::parse("en-US").unwrap();
     /// headers.encode(
     ///     &AcceptLanguage(vec![
     ///         qitem(langtag),
@@ -41,15 +39,15 @@ header! {
     /// # extern crate http;
     /// # extern crate hyperx;
     /// # #[macro_use] extern crate language_tags;
-    /// # use hyperx::header::{AcceptLanguage, QualityItem, q, qitem, TypedHeaders};
+    /// # use hyperx::header::{AcceptLanguage, LanguageTag, QualityItem, q, qitem, TypedHeaders};
     /// #
     /// # fn main() {
     /// let mut headers = http::HeaderMap::new();
     /// headers.encode(
     ///     &AcceptLanguage(vec![
-    ///         qitem(langtag!(da)),
-    ///         QualityItem::new(langtag!(en;;;GB), q(800)),
-    ///         QualityItem::new(langtag!(en), q(700)),
+    ///         qitem(LanguageTag::parse("da").unwrap()),
+    ///         QualityItem::new(LanguageTag::parse("en-US").unwrap(), q(800)),
+    ///         QualityItem::new(LanguageTag::parse("en").unwrap(), q(700)),
     ///     ])
     /// );
     /// # }

--- a/src/header/common/accept_language.rs
+++ b/src/header/common/accept_language.rs
@@ -24,10 +24,10 @@ header! {
     ///
     /// ```
     /// # extern crate http;
-    /// use hyperx::header::{AcceptLanguage, LanguageTag, qitem, TypedHeaders};
+    /// use hyperx::header::{AcceptLanguage, qitem, TypedHeaders};
     ///
     /// let mut headers = http::HeaderMap::new();
-    /// let mut langtag: LanguageTag = LanguageTag::parse("en-US").unwrap();
+    /// let mut langtag = "en-US".parse().unwrap();
     /// headers.encode(
     ///     &AcceptLanguage(vec![
     ///         qitem(langtag),
@@ -39,15 +39,15 @@ header! {
     /// # extern crate http;
     /// # extern crate hyperx;
     /// # #[macro_use] extern crate language_tags;
-    /// # use hyperx::header::{AcceptLanguage, LanguageTag, QualityItem, q, qitem, TypedHeaders};
+    /// # use hyperx::header::{AcceptLanguage, QualityItem, q, qitem, TypedHeaders};
     /// #
     /// # fn main() {
     /// let mut headers = http::HeaderMap::new();
     /// headers.encode(
     ///     &AcceptLanguage(vec![
-    ///         qitem(LanguageTag::parse("da").unwrap()),
-    ///         QualityItem::new(LanguageTag::parse("en-US").unwrap(), q(800)),
-    ///         QualityItem::new(LanguageTag::parse("en").unwrap(), q(700)),
+    ///         qitem("da".parse().unwrap()),
+    ///         QualityItem::new("en-US".parse().unwrap(), q(800)),
+    ///         QualityItem::new("en".parse().unwrap(), q(700)),
     ///     ])
     /// );
     /// # }

--- a/src/header/common/content_language.rs
+++ b/src/header/common/content_language.rs
@@ -26,14 +26,14 @@ header! {
     /// ```
     /// # extern crate http;
     /// # extern crate hyperx;
-    /// # #[macro_use] extern crate language_tags;
+    /// extern crate language_tags;
     /// # use hyperx::header::{ContentLanguage, qitem, TypedHeaders};
     /// #
     /// # fn main() {
     /// let mut headers = http::HeaderMap::new();
     /// headers.encode(
     ///     &ContentLanguage(vec![
-    ///         qitem(langtag!(en)),
+    ///         qitem(language_tags::LanguageTag::parse("en").unwrap()),
     ///     ])
     /// );
     /// # }
@@ -42,16 +42,15 @@ header! {
     /// ```
     /// # extern crate http;
     /// # extern crate hyperx;
-    /// # #[macro_use] extern crate language_tags;
+    /// extern crate language_tags;
     /// # use hyperx::header::{ContentLanguage, qitem, TypedHeaders};
-    /// #
     /// # fn main() {
     ///
     /// let mut headers = http::HeaderMap::new();
     /// headers.encode(
     ///     &ContentLanguage(vec![
-    ///         qitem(langtag!(da)),
-    ///         qitem(langtag!(en;;;GB)),
+    ///         qitem(language_tags::LanguageTag::parse("da").unwrap()),
+    ///         qitem(language_tags::LanguageTag::parse("en-GB").unwrap()),
     ///     ])
     /// );
     /// # }

--- a/src/header/common/content_language.rs
+++ b/src/header/common/content_language.rs
@@ -33,7 +33,7 @@ header! {
     /// let mut headers = http::HeaderMap::new();
     /// headers.encode(
     ///     &ContentLanguage(vec![
-    ///         qitem(language_tags::LanguageTag::parse("en").unwrap()),
+    ///         qitem("en".parse().unwrap()),
     ///     ])
     /// );
     /// # }
@@ -49,8 +49,8 @@ header! {
     /// let mut headers = http::HeaderMap::new();
     /// headers.encode(
     ///     &ContentLanguage(vec![
-    ///         qitem(language_tags::LanguageTag::parse("da").unwrap()),
-    ///         qitem(language_tags::LanguageTag::parse("en-GB").unwrap()),
+    ///         qitem("da".parse().unwrap()),
+    ///         qitem("en-GB".parse().unwrap()),
     ///     ])
     /// );
     /// # }


### PR DESCRIPTION
0.3.x is API incompatible for us, so it can't be broadened.

This requires at least a MINOR hyperx release, as there are significant API changes in 0.3.